### PR TITLE
Remove `--no-config` from default options

### DIFF
--- a/src/gmpv_player.c
+++ b/src/gmpv_player.c
@@ -390,7 +390,6 @@ static void apply_default_options(GmpvMpv *mpv)
 			{"input-cursor", "no"},
 			{"cursor-autohide", "no"},
 			{"softvol-max", "100"},
-			{"config", "no"},
 			{"config-dir", config_dir},
 			{"watch-later-directory", watch_dir},
 			{"screenshot-directory", screenshot_dir},


### PR DESCRIPTION
`--config-dir` does not have any effect when `--no-config` is passed.

Fixes https://github.com/celluloid-player/celluloid/issues/425