### PR TITLE
build: Allow validating appstream in sandbox

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -43,7 +43,7 @@ configure_file(
 
 appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
-  test('Validate appstream file', appstream_util, args: ['validate', appdata])
+  test('Validate appstream file', appstream_util, args: ['validate', '--nonet', appdata])
 endif
 
 desktop_file_validate = find_program('desktop-file-validate', required: false)


### PR DESCRIPTION
On Linux distributions, packages are often build in a sandbox without internet connection. By default, appstream-util is trying to download the images used in the appstream file, which will fail in such environments. For that reason, we need to disable network operations.