### PR TITLE
flatpak: include flatpak manifest in repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flatpak/shared-modules"]
+	path = flatpak/shared-modules
+	url = git@github.com:flathub/shared-modules.git

--- a/flatpak/io.github.celluloid_player.Celluloid.json
+++ b/flatpak/io.github.celluloid_player.Celluloid.json
@@ -1,0 +1,164 @@
+{
+    "app-id": "io.github.celluloid_player.Celluloid",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "celluloid",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=all",
+        "--share=network",
+        "--socket=pulseaudio",
+        "--filesystem=xdg-pictures",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*",
+        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+        "--env=LC_NUMERIC=C"
+    ],
+    "modules": [
+        {
+            "name": "luajit",
+            "no-autogen": true,
+            "cleanup": [ "/bin", "/lib/*.a", "/include", "/lib/pkgconfig", "/share/man" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
+                    "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "sed -i 's|/usr/local|/app|' ./Makefile" ]
+                }
+            ]
+        },
+        {
+            "name": "libv4l2",
+            "cleanup": [ "/sbin", "/bin", "/include", "/lib/*.la", "/lib/*/*.la", "/lib*/*/*/*.la", "/lib/pkgconfig", "/share/man" ],
+            "config-opts": [ "--disable-static", "--disable-bpf", "--with-udevdir=/app/lib/udev" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2",
+                    "sha256": "956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
+                }
+            ]
+        },
+        {
+            "name": "nv-codec-headers",
+            "cleanup": ["*"],
+            "no-autogen": true,
+            "make-install-args": ["PREFIX=/app"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
+                    "commit": "cf8b0b2bb70b59068b06f1d5610627c8aa6d5652"
+                }
+            ]
+        },
+        {
+            "name": "ffmpeg",
+            "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
+            "config-opts": [
+                "--enable-shared",
+                "--disable-static",
+                "--enable-gnutls",
+                "--disable-doc",
+                "--disable-programs",
+                "--disable-encoders",
+                "--disable-muxers",
+                "--enable-encoder=png",
+                "--enable-libv4l2",
+                "--enable-libdav1d"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.ffmpeg.org/ffmpeg.git"
+                }
+            ]
+        },
+        {
+            "name": "libass",
+            "cleanup": [ "/include", "/lib/*.la", "/lib/pkgconfig" ],
+            "config-opts": [ "--disable-static" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.xz",
+                    "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+                }
+            ]
+        },
+        {
+            "name": "uchardet",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_STATIC=0"
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig",
+                "/share/man"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.6.tar.xz",
+                    "sha256": "8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61"
+                }
+            ]
+        },
+        {
+            "name": "libmpv",
+            "cleanup": [ "/include", "/lib/pkgconfig", "/share/man" ],
+            "buildsystem": "simple",
+            "build-commands": [
+              "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa",
+              "python3 waf build",
+              "python3 waf install"
+            ],
+            "sources": [
+              {
+                "type": "git",
+                "url": "https://github.com/mpv-player/mpv.git"
+              },
+              {
+                "type": "file",
+                "url": "https://waf.io/waf-2.0.19",
+                "sha256": "ba63c90a865a9bcf46926c4e6776f9a3f73d29f33d49b7f61f96bc37b7397cef",
+                "dest-filename": "waf"
+              }
+            ]
+        },
+        {
+          "name": "youtube-dl",
+          "no-autogen": true,
+          "no-make-install": true,
+          "make-args": ["youtube-dl", "PYTHON=/usr/bin/python3"],
+          "post-install": ["install youtube-dl /app/bin"],
+          "sources": [{
+            "type": "git",
+            "url": "https://github.com/rg3/youtube-dl.git",
+            "tag": "2020.05.29",
+            "commit": "228c1d685bb6d35b2c1a73e1adbc085c76da6b75"
+          }]
+        },
+        {
+            "name": "celluloid",
+            "buildsystem": "meson",
+            "cleanup": ["/share/man"],
+            "sources": [
+              {
+                "type": "git",
+                "url": "https://github.com/celluloid-player/celluloid.git"
+              }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows for Celluloid to be built in one click from
apps like GNOME Builder - without installing dependencies
manually.

Closes https://github.com/celluloid-player/celluloid/issues/435