### PR TITLE
Define G_LOG_DOMAIN with default logging facility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,8 @@ AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_44], [Prevents using newer
 AC_DEFINE([GDK_VERSION_MIN_REQUIRED], [GDK_VERSION_3_22], [Dont warn using older APIs])
 AC_DEFINE([GDK_VERSION_MAX_ALLOWED], [GDK_VERSION_3_22], [Prevents using newer APIs])
 
+AC_DEFINE_UNQUOTED([G_LOG_DOMAIN], "$PACKAGE_NAME", [Default logging facility])
+
 # Checks for header files.
 AC_CHECK_HEADERS([string.h stdio.h stdlib.h locale.h],[],[
 	AC_MSG_ERROR([Could not find required headers])

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ cflags = [
   '-DPACKAGE_LOCALEDIR="@0@"'.format(localedir),
   '-DVERSION="@0@"'.format(meson.project_version()),
   '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
+  '-DG_LOG_DOMAIN="@0@"'.format(meson.project_name()),
   '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_44',
   '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_44',
   '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_22',


### PR DESCRIPTION
This helps distinguish log records without recompiling or overriding CFLAGS. So users of binary distributions can easy define the G_MESSAGES_DEBUG environment variable and see desired debug messages to investigate possible issues.

docs: https://developer.gnome.org/glib/2.66/glib-Message-Logging.html#log-domains