### PR TITLE
docs: fix simple typo, seperate -> separate

### DIFF
--- a/src/celluloid-preferences-dialog.c
+++ b/src/celluloid-preferences-dialog.c
@@ -257,7 +257,7 @@ build_page(const PreferencesDialogItem *items, GSettings *settings)
 
 			/* The grid should only have 2 columns, so the previous
 			 * widget connot be wider than 1 column if it needs a
-			 * seperate label.
+			 * separate label.
 			 */
 			g_assert(width == 1);
 


### PR DESCRIPTION
There is a small typo in src/celluloid-preferences-dialog.c.

Should read `separate` rather than `seperate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md