### PR TITLE
l10n: Fix Finnish translations

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -6,6 +6,7 @@ de
 eo
 es
 fa
+fi
 fr
 hr
 hu


### PR DESCRIPTION
Although the .po file was present in /po, the locale was
missing in po/LINGUAS.