### PR TITLE
mpris: Initialize interfaces before acquiring name

### DIFF
--- a/src/mpris/celluloid-mpris.c
+++ b/src/mpris/celluloid-mpris.c
@@ -74,11 +74,6 @@ get_property(	GObject *object,
 		GParamSpec *pspec );
 
 static void
-name_acquired_handler(	GDBusConnection *connection,
-			const gchar *name,
-			gpointer data );
-
-static void
 name_lost_handler(	GDBusConnection *connection,
 			const gchar *name,
 			gpointer data );
@@ -119,12 +114,23 @@ constructed(GObject *object)
 		gchar *name =	g_strdup_printf
 				(MPRIS_BUS_NAME ".instance-%u", window_id);
 
+		self->session_bus_conn = conn;
+		self->base =		celluloid_mpris_base_new
+			(self->controller, conn);
+		self->player =		celluloid_mpris_player_new
+			(self->controller, conn);
+		self->track_list =	celluloid_mpris_track_list_new
+			(self->controller, conn);
+
+		celluloid_mpris_module_register(self->base);
+		celluloid_mpris_module_register(self->player);
+		celluloid_mpris_module_register(self->track_list);
+
 		self->name_id =	g_bus_own_name_on_connection
 				(	conn,
 					name,
 					G_BUS_NAME_OWNER_FLAGS_NONE,
-					(GBusNameAcquiredCallback)
-					name_acquired_handler,
+					NULL,
 					(GBusNameLostCallback)
 					name_lost_handler,
 					self,
@@ -195,26 +201,6 @@ get_property(	GObject *object,
 		break;
 	}
 
-}
-
-static void
-name_acquired_handler(	GDBusConnection *connection,
-			const gchar *name,
-			gpointer data )
-{
-	CelluloidMpris *self = data;
-
-	self->session_bus_conn = connection;
-	self->base =		celluloid_mpris_base_new
-				(self->controller, connection);
-	self->player =		celluloid_mpris_player_new
-				(self->controller, connection);
-	self->track_list =	celluloid_mpris_track_list_new
-				(self->controller, connection);
-
-	celluloid_mpris_module_register(self->base);
-	celluloid_mpris_module_register(self->player);
-	celluloid_mpris_module_register(self->track_list);
 }
 
 static void


### PR DESCRIPTION
Hello,

I have not contributed to this project before and I'm not familiar with the code base, so let me know if I did everything right to contribute. I've made this change to fix an issue on a project of mine here: https://github.com/altdesktop/playerctl/issues/250 .

Some desktop applications look for media players by listening to the
DBus NameOwnerChanged signal which is emitted after a name is acquired
and match on a well-known name prefix. If the MPRIS interfaces are not
initialized at this time, it may lead to subtle bugs. Initialize the
interfaces before the name is acquired to ensure the interface is
never partially implemented.