### PR TITLE
Use Libadwaita 

### DIFF
--- a/data/io.github.GnomeMpv.gschema.xml
+++ b/data/io.github.GnomeMpv.gschema.xml
@@ -13,7 +13,7 @@
 		</key>
 		<key name='dark-theme-enable' type='b'>
 			<default>true</default>
-			<summary>Enable or disable dark theme</summary>
+			<summary>Whether to prefer dark theme or not</summary>
 			<description>
 			</description>
 		</key>

--- a/data/io.github.celluloid_player.Celluloid.gschema.xml
+++ b/data/io.github.celluloid_player.Celluloid.gschema.xml
@@ -20,7 +20,7 @@
 		</key>
 		<key name="dark-theme-enable" type="b">
 			<default>true</default>
-			<summary>Enable dark theme</summary>
+			<summary>Prefer dark theme</summary>
 			<description>
 			</description>
 		</key>

--- a/flatpak/io.github.celluloid_player.Celluloid.json
+++ b/flatpak/io.github.celluloid_player.Celluloid.json
@@ -81,7 +81,7 @@
                 }
             ]
         },
-        {
+	{
             "name": "libass",
             "cleanup": [ "/include", "/lib/*.la", "/lib/pkgconfig" ],
             "config-opts": [ "--disable-static" ],
@@ -92,7 +92,7 @@
                     "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
                 }
             ]
-        },
+        },    
         {
             "name": "uchardet",
             "buildsystem": "cmake-ninja",

--- a/flatpak/io.github.celluloid_player.Celluloid.json
+++ b/flatpak/io.github.celluloid_player.Celluloid.json
@@ -92,7 +92,7 @@
                     "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
                 }
             ]
-        },    
+        },
         {
             "name": "uchardet",
             "buildsystem": "cmake-ninja",

--- a/po/celluloid.pot
+++ b/po/celluloid.pot
@@ -27,7 +27,7 @@ msgid "Automatically resize window to fit video"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:23
-msgid "Enable dark theme"
+msgid "Prefer dark theme"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:29

--- a/src/celluloid-application.c
+++ b/src/celluloid-application.c
@@ -23,7 +23,7 @@
 #include <glib-unix.h>
 #include <gio/gio.h>
 #include <gdk/gdk.h>
-
+#include <adwaita.h>
 #ifdef GDK_WINDOWING_X11
 #include <gdk/x11/gdkx.h>
 #endif
@@ -205,6 +205,7 @@ initialize_gui(CelluloidApplication *app)
 				G_SETTINGS_BIND_GET );
 
 	g_object_unref(settings);
+	adw_init();
 }
 
 static void

--- a/src/celluloid-application.c
+++ b/src/celluloid-application.c
@@ -200,8 +200,8 @@ initialize_gui(CelluloidApplication *app)
 				G_SETTINGS_BIND_GET );
 	g_settings_bind(	settings,
 				"dark-theme-enable",
-				gtk_settings_get_default(),
-				"gtk-application-prefer-dark-theme",
+				controller,
+				"dark-theme-enable",
 				G_SETTINGS_BIND_GET );
 
 	g_object_unref(settings);

--- a/src/celluloid-controller-private.h
+++ b/src/celluloid-controller-private.h
@@ -34,6 +34,7 @@ enum
 	PROP_READY,
 	PROP_IDLE,
 	PROP_USE_SKIP_BUTTONS_FOR_PLAYLIST,
+  PROP_DARK_THEME_ENABLE,
 	N_PROPERTIES
 };
 
@@ -49,6 +50,7 @@ struct _CelluloidController
 	gboolean ready;
 	gboolean idle;
 	gboolean use_skip_buttons_for_playlist;
+  gboolean dark_theme_enable;
 	gint64 target_playlist_pos;
 	guint update_seekbar_id;
 	guint resize_timeout_tag;

--- a/src/celluloid-controller-private.h
+++ b/src/celluloid-controller-private.h
@@ -34,7 +34,7 @@ enum
 	PROP_READY,
 	PROP_IDLE,
 	PROP_USE_SKIP_BUTTONS_FOR_PLAYLIST,
-  PROP_DARK_THEME_ENABLE,
+	PROP_DARK_THEME_ENABLE,
 	N_PROPERTIES
 };
 
@@ -50,7 +50,7 @@ struct _CelluloidController
 	gboolean ready;
 	gboolean idle;
 	gboolean use_skip_buttons_for_playlist;
-  gboolean dark_theme_enable;
+	gboolean dark_theme_enable;
 	gint64 target_playlist_pos;
 	guint update_seekbar_id;
 	guint resize_timeout_tag;

--- a/src/celluloid-controller.c
+++ b/src/celluloid-controller.c
@@ -23,7 +23,7 @@
 #include <gtk/gtk.h>
 #include <glib-unix.h>
 #include <locale.h>
-
+#include <adwaita.h>
 #include "celluloid-controller-private.h"
 #include "celluloid-controller.h"
 #include "celluloid-controller-actions.h"
@@ -116,6 +116,10 @@ playlist_reordered_handler(	CelluloidView *view,
 
 static void
 set_use_skip_button_for_playlist(	CelluloidController *controller,
+					gboolean value);
+
+static void
+set_dark_theme_enable(	CelluloidController *controller,
 					gboolean value);
 
 static void
@@ -313,6 +317,12 @@ set_property(	GObject *object,
 			(self, self->use_skip_buttons_for_playlist);
 		break;
 
+		case PROP_DARK_THEME_ENABLE:
+		self->dark_theme_enable = g_value_get_boolean(value);
+		set_dark_theme_enable
+			(self, self->dark_theme_enable);
+		break;
+
 		default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 		break;
@@ -343,6 +353,10 @@ get_property(	GObject *object,
 
 		case PROP_USE_SKIP_BUTTONS_FOR_PLAYLIST:
 		g_value_set_boolean(value, self->use_skip_buttons_for_playlist);
+		break;
+
+    case PROP_DARK_THEME_ENABLE:
+    g_value_set_boolean(value, self->dark_theme_enable);
 		break;
 
 		default:
@@ -611,7 +625,21 @@ set_use_skip_button_for_playlist(	CelluloidController *controller,
 				NULL,
 				NULL );
 }
+static void
+set_dark_theme_enable(	CelluloidController *controller,
+					gboolean value )
+{
+  if(controller->dark_theme_enable) {
+    adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
+                                    ADW_COLOR_SCHEME_PREFER_DARK);
 
+  }
+  else {
+    adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
+                                    ADW_COLOR_SCHEME_DEFAULT);
+  }
+
+}
 static void
 connect_signals(CelluloidController *controller)
 {
@@ -1274,6 +1302,14 @@ celluloid_controller_class_init(CelluloidControllerClass *klass)
 			FALSE,
 			G_PARAM_READWRITE );
 	g_object_class_install_property(obj_class, PROP_USE_SKIP_BUTTONS_FOR_PLAYLIST, pspec);
+
+  pspec = g_param_spec_boolean
+		(	"dark-theme-enable",
+			"Enable dark theme",
+			"Whether or not to enable dark theme",
+			FALSE,
+			G_PARAM_READWRITE );
+	g_object_class_install_property(obj_class, PROP_DARK_THEME_ENABLE, pspec);
 
 	g_signal_new(	"shutdown",
 			G_TYPE_FROM_CLASS(klass),

--- a/src/celluloid-controller.c
+++ b/src/celluloid-controller.c
@@ -355,8 +355,8 @@ get_property(	GObject *object,
 		g_value_set_boolean(value, self->use_skip_buttons_for_playlist);
 		break;
 
-    case PROP_DARK_THEME_ENABLE:
-    g_value_set_boolean(value, self->dark_theme_enable);
+		case PROP_DARK_THEME_ENABLE:
+		g_value_set_boolean(value, self->dark_theme_enable);
 		break;
 
 		default:
@@ -629,15 +629,16 @@ static void
 set_dark_theme_enable(	CelluloidController *controller,
 					gboolean value )
 {
-  if(controller->dark_theme_enable) {
-    adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
-                                    ADW_COLOR_SCHEME_PREFER_DARK);
-
-  }
-  else {
-    adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
-                                    ADW_COLOR_SCHEME_DEFAULT);
-  }
+	if(controller->dark_theme_enable)
+	{
+	adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
+																		ADW_COLOR_SCHEME_PREFER_DARK);
+	}
+	else
+	{
+		adw_style_manager_set_color_scheme (adw_style_manager_get_default (),
+																		ADW_COLOR_SCHEME_DEFAULT);
+	}
 
 }
 static void

--- a/src/celluloid-view.c
+++ b/src/celluloid-view.c
@@ -587,9 +587,6 @@ load_settings(CelluloidView *view)
 			"show-fullscreen-button", !csd_enable,
 			"skip-enabled", FALSE,
 			NULL );
-	g_object_set(	gtk_settings_get_default(),
-			"gtk-application-prefer-dark-theme", dark_theme_enable,
-			NULL );
 
 	g_object_unref(settings);
 }

--- a/src/celluloid-view.c
+++ b/src/celluloid-view.c
@@ -577,11 +577,8 @@ load_settings(CelluloidView *view)
 		celluloid_main_window_get_control_box(wnd);
 
 	gboolean csd_enable;
-	gboolean dark_theme_enable;
 
 	csd_enable =	g_settings_get_boolean (settings, "csd-enable");
-	dark_theme_enable =	g_settings_get_boolean
-				(settings, "dark-theme-enable");
 
 	g_object_set(	control_box,
 			"show-fullscreen-button", !csd_enable,

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,7 +131,7 @@ executable('celluloid', sources,
     libgio,
     meson.get_compiler('c').find_library('m', required: false),
     dependency('mpv', version: '>= 1.107'),
-    dependency('libadwaita-1', version: '>= 1.0.0-alpha.1'),
+    dependency('libadwaita-1', version: '>= 1.0.0-alpha.3'),
     dependency('epoxy')
   ],
   link_with: extra_libs,

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,6 +131,7 @@ executable('celluloid', sources,
     libgio,
     meson.get_compiler('c').find_library('m', required: false),
     dependency('mpv', version: '>= 1.107'),
+    dependency('libadwaita-1', version: '>= 1.0.0-alpha.1'),
     dependency('epoxy')
   ],
   link_with: extra_libs,


### PR DESCRIPTION
Gives us the new stylesheet as well as (eventually) [proper dark style API. ](https://gitlab.gnome.org/GNOME/Initiatives/-/wikis/Dark-Style-Preference)

TODO: 

- [x] Use `AdwStyleManager` instead of `GtkSettings:gtk-application-prefer-dark-theme` - otherwise it appears broken. 
- [x] Deal with system-wide preference somehow 
- [x] Cleanup stuff