### PR TITLE
video-area: unbreak build with X11-less Gtk4

### DIFF
--- a/src/celluloid-video-area.c
+++ b/src/celluloid-video-area.c
@@ -25,7 +25,6 @@
 
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
-#include <gdk/x11/gdkx.h>
 #include <glib-object.h>
 #include <math.h>
 


### PR DESCRIPTION
Regressed by 02c1e86dae64. From [error log](https://github.com/celluloid-player/celluloid/files/7801826/celluloid-0.22.log):
```c
../src/celluloid-video-area.c:28:10: fatal error: 'gdk/x11/gdkx.h' file not found
#include <gdk/x11/gdkx.h>
         ^~~~~~~~~~~~~~~~
```
