### PR TITLE
meson-post-install.py: use gtk4-update-icon-cache

### DIFF
--- a/meson-post-install.py
+++ b/meson-post-install.py
@@ -12,7 +12,7 @@ if not 'DESTDIR' in os.environ:
 	subprocess.call(['glib-compile-schemas', os.path.join(datadir, 'glib-2.0', 'schemas')])
 
 	print('Updating icon cache...')
-	subprocess.call(['gtk-update-icon-cache', '-qtf', os.path.join(datadir, 'icons', 'hicolor')])
+	subprocess.call(['gtk4-update-icon-cache', '-qtf', os.path.join(datadir, 'icons', 'hicolor')])
 
 	print('Updating desktop database...')
 	subprocess.call(['update-desktop-database', '-q', os.path.join(datadir, 'applications')])


### PR DESCRIPTION
Current script fails if gtk3 is not installed.