### PR TITLE
Reword some unnatural-sounding sentences

### DIFF
--- a/po/celluloid.pot
+++ b/po/celluloid.pot
@@ -663,11 +663,11 @@ msgid "_File"
 msgstr ""
 
 #: src/celluloid-menu.c:236 src/celluloid-menu.c:318
-msgid "_Open…"
+msgid "_Open File…"
 msgstr ""
 
 #: src/celluloid-menu.c:237 src/celluloid-menu.c:319
-msgid "Open _Folder…"
+msgid "Open Directory…"
 msgstr ""
 
 #: src/celluloid-menu.c:238 src/celluloid-menu.c:320

--- a/po/celluloid.pot
+++ b/po/celluloid.pot
@@ -53,11 +53,11 @@ msgid ""
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:60
-msgid "Use skip buttons for controlling playlist"
+msgid "Use skip buttons to control the playlist"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:66
-msgid "Make file chooser remember last file's location"
+msgid "Remember last location in file chooser"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:72
@@ -79,12 +79,12 @@ msgid ""
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:93
-msgid "Present window when opening new files"
+msgid "Give focus to the window when opening new files"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:94
 msgid ""
-"If true, Celluloid will attempt to present its window to the user when a new "
+"If true, Celluloid will give focus to the window when a new "
 "file is opened. If false, no attempt will be made."
 msgstr ""
 
@@ -154,11 +154,11 @@ msgid "Width of the playlist"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:204
-msgid "Show or not show the controls"
+msgid "Show/hide the controls"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:210
-msgid "Show or not show the playlist"
+msgid "Show/hide the playlist"
 msgstr ""
 
 #: data/io.github.celluloid_player.Celluloid.gschema.xml:216


### PR DESCRIPTION
I reworded a few sentences, and fixed "Ctrl+F" still showing up as a shortcut for "Open Folder…".