### PR TITLE
control-box: floatier controls

### DIFF
--- a/src/celluloid-control-box.c
+++ b/src/celluloid-control-box.c
@@ -645,7 +645,7 @@ celluloid_control_box_init(CelluloidControlBox *box)
 		(GTK_WIDGET(box), GTK_EVENT_CONTROLLER(box->click_gesture));
 
 	gtk_style_context_add_class
-		(gtk_widget_get_style_context(GTK_WIDGET(box)), "background");
+		(gtk_widget_get_style_context(GTK_WIDGET(box)), "toolbar");
 
 	gtk_widget_set_margin_end(box->seek_bar, 6);
 
@@ -789,6 +789,29 @@ gboolean
 celluloid_control_box_get_volume_popup_visible(CelluloidControlBox *box)
 {
 	return box->volume_popup_visible;
+}
+
+void
+celluloid_control_box_set_floating(CelluloidControlBox *box, gboolean floating)
+{
+	if(floating) {
+		gtk_style_context_add_class
+		(gtk_widget_get_style_context(GTK_WIDGET(box)), "osd");
+
+		gtk_widget_set_margin_start(GTK_WIDGET(box), 12);
+		gtk_widget_set_margin_end(GTK_WIDGET(box), 12);
+		gtk_widget_set_margin_top(GTK_WIDGET(box), 12);
+		gtk_widget_set_margin_bottom(GTK_WIDGET(box), 12);
+	}
+	else {
+		gtk_style_context_remove_class
+		(gtk_widget_get_style_context(GTK_WIDGET(box)), "osd");
+
+		gtk_widget_set_margin_start(GTK_WIDGET(box), 0);
+		gtk_widget_set_margin_end(GTK_WIDGET(box), 0);
+		gtk_widget_set_margin_top(GTK_WIDGET(box), 0);
+		gtk_widget_set_margin_bottom(GTK_WIDGET(box), 0);
+	}
 }
 
 void

--- a/src/celluloid-control-box.h
+++ b/src/celluloid-control-box.h
@@ -53,6 +53,10 @@ gboolean
 celluloid_control_box_get_volume_popup_visible(CelluloidControlBox *box);
 
 void
+celluloid_control_box_set_floating(	CelluloidControlBox *box,
+						gboolean floating );
+
+void
 celluloid_control_box_reset(CelluloidControlBox *box);
 
 G_END_DECLS

--- a/src/celluloid-video-area.c
+++ b/src/celluloid-video-area.c
@@ -420,11 +420,14 @@ celluloid_video_area_init(CelluloidVideoArea *area)
 	gtk_widget_set_valign(area->control_box_revealer, GTK_ALIGN_END);
 	gtk_revealer_set_transition_type
 		(GTK_REVEALER(area->control_box_revealer),
-		GTK_REVEALER_TRANSITION_TYPE_SLIDE_UP);
+		GTK_REVEALER_TRANSITION_TYPE_CROSSFADE);
 	gtk_revealer_set_reveal_child
 		(GTK_REVEALER(area->control_box_revealer), FALSE);
 
 	gtk_widget_set_valign(area->header_bar_revealer, GTK_ALIGN_START);
+	gtk_revealer_set_transition_type
+		(GTK_REVEALER(area->control_box_revealer),
+		GTK_REVEALER_TRANSITION_TYPE_CROSSFADE);
 	gtk_revealer_set_reveal_child
 		(GTK_REVEALER(area->header_bar_revealer), FALSE);
 
@@ -534,6 +537,8 @@ celluloid_video_area_init(CelluloidVideoArea *area)
 
 	gtk_overlay_set_child(GTK_OVERLAY(area->overlay), area->stack);
 	gtk_box_append(GTK_BOX(area), area->overlay);
+
+	celluloid_control_box_set_floating (CELLULOID_CONTROL_BOX (area->control_box), TRUE);
 }
 
 GtkWidget *


### PR DESCRIPTION
Part of #696 

Adds .toobar and .osd styles to the seekbar box, making click targets larger and the seekbar less intrusive.
![Screenshot from 2022-03-28 19-21-48](https://user-images.githubusercontent.com/27908024/160397744-74dc0686-3edd-4eca-b659-ddb4b111ebdb.png)

It'd would be better to not apply .osd and padding with floating controls turned off, since it looks quite silly right now:

![Screenshot from 2022-03-28 19-28-12](https://user-images.githubusercontent.com/27908024/160398394-0f9af838-ea34-40ac-a397-08fd46368357.png)


Not too sure what would be the best way to implement that at the moment though.
