### PR TITLE
Re-enable handling of horizontal scroll events

### DIFF
--- a/src/celluloid-controller-input.c
+++ b/src/celluloid-controller-input.c
@@ -339,7 +339,7 @@ celluloid_controller_input_connect_signals(CelluloidController *controller)
 
 	GtkEventController *scroll_controller =
 		gtk_event_controller_scroll_new
-		(GTK_EVENT_CONTROLLER_SCROLL_VERTICAL);
+		(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES);
 	gtk_widget_add_controller
 		(GTK_WIDGET(video_area), GTK_EVENT_CONTROLLER(scroll_controller));
 


### PR DESCRIPTION
Set up the `GtkEventControllerScroll` to emit motion for both vertical and horizontal scroll events, instead of just vertical ones.

This re-enables seeking forwards/backwards via horizontal scroll events (i.e., pushing the scroll wheel on mouse to left or right), which has been lost during transition to `Gtk4`.