### PR TITLE
mpris: notify track change even if metadata is empty

### DIFF
--- a/src/celluloid-player.c
+++ b/src/celluloid-player.c
@@ -1000,7 +1000,7 @@ update_metadata(CelluloidPlayer *player)
 
 	org_list = metadata.u.list;
 
-	if(metadata.format == MPV_FORMAT_NODE_MAP && org_list->num > 0)
+	if(metadata.format == MPV_FORMAT_NODE_MAP)
 	{
 		for(gint i = 0; i < org_list->num; i++)
 		{


### PR DESCRIPTION
You may find this patch interesting. It fixes a mistake in signal name, `notify::metadata` was replaced with `metadata-update`.
Tested against Celluloid 0.20 under KDE Plasma 5.20.5, both from Debian stable.

Probably related to #649.