### PR TITLE
preferences-dialog: Port to libadwaita widgetry

### DIFF
--- a/src/celluloid-plugins-manager-item.c
+++ b/src/celluloid-plugins-manager-item.c
@@ -22,6 +22,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gi18n.h>
+#include <adwaita.h>
 
 #include "celluloid-plugins-manager-item.h"
 
@@ -29,25 +30,23 @@ enum
 {
 	PROP_0,
 	PROP_PARENT,
-	PROP_TITLE,
 	PROP_PATH,
 	N_PROPERTIES
 };
 
 struct _CelluloidPluginsManagerItem
 {
-	GtkListBoxRow parent;
+	AdwActionRow parent;
 	GtkWindow *parent_window;
-	gchar *title;
 	gchar *path;
 };
 
 struct _CelluloidPluginsManagerItemClass
 {
-	GtkListBoxRowClass parent_class;
+	AdwActionRowClass parent_class;
 };
 
-G_DEFINE_TYPE(CelluloidPluginsManagerItem, celluloid_plugins_manager_item, GTK_TYPE_LIST_BOX_ROW)
+G_DEFINE_TYPE(CelluloidPluginsManagerItem, celluloid_plugins_manager_item, ADW_TYPE_ACTION_ROW)
 
 static void
 celluloid_plugins_manager_item_constructed(GObject *object);
@@ -68,33 +67,23 @@ celluloid_plugins_manager_item_get_property(	GObject *object,
 						GParamSpec *pspec );
 
 static void
-remove_response_handler(GtkDialog *dialog, gint response_id, gpointer data);
-
-static void
 remove_handler(GtkButton *button, gpointer data);
 
 static void
 celluloid_plugins_manager_item_constructed(GObject *object)
 {
 	CelluloidPluginsManagerItem *self = CELLULOID_PLUGINS_MANAGER_ITEM(object);
-	GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	GtkWidget *title_label = gtk_label_new(self->title);
-	GtkWidget *remove_button = gtk_button_new_with_label(_("Remove"));
+	GtkWidget *remove_button = gtk_button_new_from_icon_name("user-trash-symbolic");
+	gtk_widget_add_css_class(remove_button, "flat");
+	gtk_widget_set_valign(remove_button, GTK_ALIGN_CENTER);
+	gtk_widget_set_tooltip_text(remove_button, _("Remove Plugin"));
 
 	g_signal_connect(	remove_button,
 				"clicked",
 				G_CALLBACK(remove_handler),
 				self );
 
-	gtk_widget_set_halign(title_label, GTK_ALIGN_START);
-	gtk_widget_set_hexpand(title_label, TRUE);
-	gtk_widget_set_margin_start(title_label, 6);
-	gtk_label_set_ellipsize(GTK_LABEL(title_label), PANGO_ELLIPSIZE_END);
-	gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(self), FALSE);
-
-	gtk_box_append(GTK_BOX(box), title_label);
-	gtk_box_append(GTK_BOX(box), remove_button);
-	gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(self), box);
+	adw_action_row_add_suffix(ADW_ACTION_ROW (self), remove_button);
 
 	G_OBJECT_CLASS(celluloid_plugins_manager_item_parent_class)
 		->constructed(object);
@@ -105,7 +94,6 @@ celluloid_plugins_manager_item_finalize(GObject *object)
 {
 	CelluloidPluginsManagerItem *self = CELLULOID_PLUGINS_MANAGER_ITEM(object);
 
-	g_free(self->title);
 	g_free(self->path);
 
 	G_OBJECT_CLASS(celluloid_plugins_manager_item_parent_class)
@@ -123,12 +111,6 @@ celluloid_plugins_manager_item_set_property(	GObject *object,
 	if(property_id == PROP_PARENT)
 	{
 		self->parent_window = g_value_get_pointer(value);
-	}
-	else if(property_id == PROP_TITLE)
-	{
-		g_free(self->title);
-
-		self->title = g_value_dup_string(value);
 	}
 	else if(property_id == PROP_PATH)
 	{
@@ -154,10 +136,6 @@ celluloid_plugins_manager_item_get_property(	GObject *object,
 	{
 		g_value_set_pointer(value, self->parent_window);
 	}
-	else if(property_id == PROP_TITLE)
-	{
-		g_value_set_string(value, self->title);
-	}
 	else if(property_id == PROP_PATH)
 	{
 		g_value_set_string(value, self->path);
@@ -167,15 +145,14 @@ celluloid_plugins_manager_item_get_property(	GObject *object,
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 	}
 }
-
 static void
-remove_response_handler(GtkDialog *dialog, gint response_id, gpointer data)
+remove_response_handler(AdwMessageDialog *dialog, gchar* response_id, gpointer data)
 {
 	CelluloidPluginsManagerItem *item = data;
 	GFile *file = g_file_new_for_path(item->path);
 	GError *error = NULL;
 
-	if(response_id == GTK_RESPONSE_YES)
+	if(strcmp (response_id, "remove") == 0)
 	{
 		g_file_delete(file, NULL, &error);
 	}
@@ -186,23 +163,20 @@ remove_response_handler(GtkDialog *dialog, gint response_id, gpointer data)
 	{
 		GtkWidget *error_dialog;
 
-		error_dialog =	gtk_message_dialog_new
+		error_dialog =	adw_message_dialog_new
 				(	item->parent_window,
-					GTK_DIALOG_MODAL|
-					GTK_DIALOG_DESTROY_WITH_PARENT,
-					GTK_MESSAGE_ERROR,
-					GTK_BUTTONS_OK,
-					_("Failed to delete file '%s'. "
-					"Reason: %s"),
-					g_file_get_uri(file),
-					error->message );
-
+					NULL,
+					NULL);
+		adw_message_dialog_format_body (ADW_MESSAGE_DIALOG (error_dialog),
+                                _("Failed to delete file '%s'. Reason: %s"),
+                                g_file_get_uri(file),
+								error->message);
+								
 		g_warning(	"Failed to delete file '%s'. Reason: %s",
 				g_file_get_uri(file),
 				error->message );
 
-		gtk_window_set_modal(GTK_WINDOW(error_dialog), TRUE);
-		gtk_widget_show(error_dialog);
+		gtk_window_present(error_dialog);
 
 		gtk_window_destroy(GTK_WINDOW(error_dialog));
 		g_error_free(error);
@@ -215,23 +189,26 @@ static void
 remove_handler(GtkButton *button, gpointer data)
 {
 	CelluloidPluginsManagerItem *item = data;
-	GtkWidget *confirm_dialog =	gtk_message_dialog_new
+	GtkWidget *confirm_dialog =	adw_message_dialog_new
 					(	item->parent_window,
-						GTK_DIALOG_MODAL|
-						GTK_DIALOG_DESTROY_WITH_PARENT,
-						GTK_MESSAGE_QUESTION,
-						GTK_BUTTONS_YES_NO,
+						NULL, 
 						_("Are you sure you want to "
 						"remove this script? This "
 						"action cannot be undone."));
 
-	g_signal_connect(	confirm_dialog,
-				"response",
-				G_CALLBACK(remove_response_handler),
-				item );
+	adw_message_dialog_add_responses (ADW_MESSAGE_DIALOG(confirm_dialog),
+                                  "remove",  _("_Remove"),
+                                  "keep", _("_Keep"),
+                                  NULL);
+								
+	adw_message_dialog_set_response_appearance (ADW_MESSAGE_DIALOG(confirm_dialog), "remove", ADW_RESPONSE_DESTRUCTIVE);
 
-	gtk_window_set_modal(GTK_WINDOW(confirm_dialog), TRUE);
-	gtk_widget_show(confirm_dialog);
+	adw_message_dialog_set_default_response (ADW_MESSAGE_DIALOG(confirm_dialog), "keep");
+	adw_message_dialog_set_close_response (ADW_MESSAGE_DIALOG(confirm_dialog), "keep");
+
+	g_signal_connect (confirm_dialog, "response", G_CALLBACK(remove_response_handler), item);
+
+	gtk_window_present (GTK_WINDOW(confirm_dialog));
 }
 
 static void
@@ -253,14 +230,6 @@ celluloid_plugins_manager_item_class_init(CelluloidPluginsManagerItemClass *klas
 	g_object_class_install_property(obj_class, PROP_PARENT, pspec);
 
 	pspec = g_param_spec_string
-		(	"title",
-			"Title",
-			"The string to display as the title of the item",
-			"",
-			G_PARAM_CONSTRUCT_ONLY|G_PARAM_READWRITE );
-	g_object_class_install_property(obj_class, PROP_TITLE, pspec);
-
-	pspec = g_param_spec_string
 		(	"path",
 			"Path",
 			"The path to the file that this item references",
@@ -273,7 +242,6 @@ static void
 celluloid_plugins_manager_item_init(CelluloidPluginsManagerItem *item)
 {
 	item->parent_window = NULL;
-	item->title = NULL;
 	item->path = NULL;
 }
 

--- a/src/celluloid-plugins-manager-item.h
+++ b/src/celluloid-plugins-manager-item.h
@@ -23,12 +23,13 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+#include <adwaita.h>
 
 G_BEGIN_DECLS
 
 #define CELLULOID_TYPE_PLUGINS_MANAGER_ITEM (celluloid_plugins_manager_item_get_type ())
 
-G_DECLARE_FINAL_TYPE(CelluloidPluginsManagerItem, celluloid_plugins_manager_item, CELLULOID, PLUGINS_MANAGER_ITEM, GtkListBoxRow)
+G_DECLARE_FINAL_TYPE(CelluloidPluginsManagerItem, celluloid_plugins_manager_item, CELLULOID, PLUGINS_MANAGER_ITEM, AdwActionRow )
 
 GtkWidget *
 celluloid_plugins_manager_item_new(	GtkWindow *parent,
@@ -38,3 +39,4 @@ celluloid_plugins_manager_item_new(	GtkWindow *parent,
 G_END_DECLS
 
 #endif
+

--- a/src/celluloid-plugins-manager.c
+++ b/src/celluloid-plugins-manager.c
@@ -18,6 +18,7 @@
  */
 
 #include <glib/gi18n.h>
+#include <adwaita.h>
 
 #include "celluloid-plugins-manager.h"
 #include "celluloid-plugins-manager-item.h"
@@ -33,20 +34,20 @@ enum
 
 struct _CelluloidPluginsManager
 {
-	GtkGrid parent;
+	AdwPreferencesPage parent;
 	GtkWindow *parent_window;
-	GtkWidget *list_box;
-	GtkWidget *placeholder_label;
+	AdwPreferencesGroup *pref_group;
+	GtkWidget *placeholder;
 	GFileMonitor *monitor;
 	gchar *directory;
 };
 
 struct _CelluloidPluginsManagerClass
 {
-	GtkGridClass parent_class;
+	AdwPreferencesPage parent_class;
 };
 
-G_DEFINE_TYPE(CelluloidPluginsManager, celluloid_plugins_manager, GTK_TYPE_GRID)
+G_DEFINE_TYPE(CelluloidPluginsManager, celluloid_plugins_manager, ADW_TYPE_PREFERENCES_PAGE)
 
 static void
 celluloid_plugins_manager_constructed(GObject *object);
@@ -248,18 +249,21 @@ changed_handler(	GFileMonitor *monitor,
 
 	if(dir)
 	{
-		GtkListBox *list_box;
+		AdwPreferencesGroup *pref_group;
 		GtkWidget *first_child;
+		GtkWidget *list_box;
 
-		list_box = GTK_LIST_BOX(pmgr->list_box);
-		first_child = gtk_widget_get_first_child(pmgr->list_box);
+		pref_group = ADW_PREFERENCES_GROUP (pmgr->pref_group);
+		// It's not possible to cleanly delete PreferenceGroup's children, hence this hack.
+		list_box = gtk_widget_get_first_child( gtk_widget_get_last_child (gtk_widget_get_first_child (pref_group)));
+		first_child = gtk_widget_get_first_child (list_box);
 
 		// Empty the list box
 		while(first_child)
 		{
 			gtk_list_box_remove(list_box, first_child);
 
-			first_child = gtk_widget_get_first_child(pmgr->list_box);
+			first_child = gtk_widget_get_first_child(list_box);
 		}
 
 		// Populate the list box with files in the plugins directory
@@ -279,7 +283,7 @@ changed_handler(	GFileMonitor *monitor,
 					(	pmgr->parent_window,
 						filename,
 						full_path );
-				gtk_list_box_append(list_box, item);
+				adw_preferences_group_add(pmgr->pref_group, item);
 
 				empty = FALSE;
 			}
@@ -288,7 +292,7 @@ changed_handler(	GFileMonitor *monitor,
 		}
 		while(filename);
 
-		gtk_widget_set_visible(pmgr->placeholder_label, empty);
+		gtk_widget_set_visible(pmgr->placeholder, empty);
 
 		g_dir_close(dir);
 	}
@@ -380,15 +384,24 @@ celluloid_plugins_manager_class_init(CelluloidPluginsManagerClass *klass)
 static void
 celluloid_plugins_manager_init(CelluloidPluginsManager *pmgr)
 {
-	GtkWidget *scrolled_window = gtk_scrolled_window_new();
-	GtkWidget *overlay = gtk_overlay_new();
-	GtkWidget *add_button = gtk_button_new_with_label("+");
+	GtkWidget *add_button = gtk_button_new();
+	GtkWidget *add_button_child = adw_button_content_new();
 
-	pmgr->list_box = gtk_list_box_new();
-	pmgr->placeholder_label = gtk_label_new(_("No plugins found"));
+	adw_preferences_page_set_title(pmgr, _("Plugins"));
+	adw_preferences_page_set_icon_name(pmgr, "application-x-addon-symbolic");
+
+	gtk_widget_add_css_class(add_button, "flat");
+	adw_button_content_set_label(add_button_child, _("Add…"));
+	adw_button_content_set_icon_name(add_button_child, "list-add-symbolic");
+	gtk_button_set_child(add_button, add_button_child);
+
+	pmgr->pref_group = adw_preferences_group_new();
+	pmgr->placeholder = adw_status_page_new();
 	pmgr->parent_window = NULL;
 	pmgr->monitor = NULL;
 	pmgr->directory = NULL;
+
+	adw_preferences_group_set_header_suffix(pmgr->pref_group, add_button);
 
 	g_signal_connect(	add_button,
 				"clicked",
@@ -399,35 +412,25 @@ celluloid_plugins_manager_init(CelluloidPluginsManager *pmgr)
 		gtk_drop_target_new(G_TYPE_FILE, GDK_ACTION_COPY);
 
 	gtk_widget_add_controller
-		(pmgr->list_box, GTK_EVENT_CONTROLLER(drop_target));
+		(pmgr, GTK_EVENT_CONTROLLER(drop_target));
 
 	g_signal_connect(	drop_target,
 				"drop",
 				G_CALLBACK(drop_handler),
 				pmgr );
 
-	gtk_widget_set_hexpand(GTK_WIDGET(scrolled_window), TRUE);
-	gtk_widget_set_vexpand(GTK_WIDGET(scrolled_window), TRUE);
-
 	gtk_widget_set_tooltip_text(add_button, _("Add Plugin"));
-	gtk_widget_set_sensitive(pmgr->placeholder_label, FALSE);
-	gtk_widget_show(pmgr->placeholder_label);
 
-	gtk_overlay_set_child(GTK_OVERLAY(overlay), scrolled_window);
-	gtk_overlay_add_overlay(GTK_OVERLAY(overlay), pmgr->placeholder_label);
+	adw_status_page_set_title(ADW_STATUS_PAGE(pmgr->placeholder),_("No Plugins Found"));
+	adw_status_page_set_icon_name(ADW_STATUS_PAGE(pmgr->placeholder), "application-x-addon-symbolic");
+	gtk_widget_set_vexpand(pmgr->placeholder, true);
+	gtk_widget_add_css_class(pmgr->placeholder,"card");
+	adw_preferences_group_add (ADW_PREFERENCES_GROUP(pmgr->pref_group), pmgr->placeholder);
 
-	gtk_grid_attach(	GTK_GRID(pmgr),
-				overlay,
-				0, 0, 1, 1 );
-	gtk_grid_attach(	GTK_GRID(pmgr),
-				add_button,
-				0, 1, 1, 1 );
-
-	gtk_scrolled_window_set_child
-		(GTK_SCROLLED_WINDOW(scrolled_window), pmgr->list_box);
+	adw_preferences_page_add(pmgr, pmgr->pref_group);
 }
 
-GtkWidget *
+AdwPreferencesPage *
 celluloid_plugins_manager_new(GtkWindow *parent)
 {
 	return g_object_new(	celluloid_plugins_manager_get_type(),

--- a/src/celluloid-plugins-manager.h
+++ b/src/celluloid-plugins-manager.h
@@ -23,6 +23,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+#include <adwaita.h>
 
 G_BEGIN_DECLS
 
@@ -30,7 +31,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE(CelluloidPluginsManager, celluloid_plugins_manager, CELLULOID, PLUGINS_MANAGER, GtkGrid)
 
-GtkWidget *
+AdwPreferencesPage *
 celluloid_plugins_manager_new(GtkWindow *parent);
 
 void

--- a/src/celluloid-preferences-dialog.c
+++ b/src/celluloid-preferences-dialog.c
@@ -81,7 +81,7 @@ save_settings(AdwPreferencesWindow *dialog)
 {
 	CelluloidPreferencesDialog *dlg = CELLULOID_PREFERENCES_DIALOG(dialog);
 	g_settings_apply(dlg->settings);
-  gtk_window_close(dlg);
+	gtk_window_close(dlg);
 }
 
 static void
@@ -304,10 +304,8 @@ celluloid_preferences_dialog_init(CelluloidPreferencesDialog *dlg)
 					build_page(config_items, dlg->settings, "Config Files", "document-properties-symbolic"));
 	adw_preferences_window_add(	ADW_PREFERENCES_WINDOW(dlg),
 					build_page(misc_items, dlg->settings, "Miscellaneous", "preferences-other-symbolic"));
+	adw_preferences_window_add(	ADW_PREFERENCES_WINDOW(dlg), ADW_PREFERENCES_PAGE(celluloid_plugins_manager_new(GTK_WINDOW(dlg))) );
 
-	/* gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook), */
-	/* 				celluloid_plugins_manager_new(GTK_WINDOW(dlg)), */
-	/* 				gtk_label_new(_("Plugins")) ); */
 	g_signal_connect(	dlg,
 				"close_request",
 				G_CALLBACK(save_settings),

--- a/src/celluloid-preferences-dialog.c
+++ b/src/celluloid-preferences-dialog.c
@@ -22,6 +22,7 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gi18n.h>
+#include <adwaita.h>
 
 #include "celluloid-preferences-dialog.h"
 #include "celluloid-file-chooser-button.h"
@@ -34,23 +35,20 @@ typedef enum PreferencesDialogItemType PreferencesDialogItemType;
 
 struct _CelluloidPreferencesDialog
 {
-	GtkDialog parent_instance;
+	AdwPreferencesWindow parent_instance;
 	GSettings *settings;
-	GtkWidget *notebook;
 };
 
 struct _CelluloidPreferencesDialogClass
 {
-	GtkDialogClass parent_class;
+	AdwPreferencesWindowClass parent_class;
 };
 
 enum PreferencesDialogItemType
 {
 	ITEM_TYPE_INVALID,
-	ITEM_TYPE_GROUP,
-	ITEM_TYPE_CHECK_BOX,
+	ITEM_TYPE_SWITCH,
 	ITEM_TYPE_FILE_CHOOSER,
-	ITEM_TYPE_LABEL,
 	ITEM_TYPE_TEXT_BOX
 };
 
@@ -61,7 +59,7 @@ struct PreferencesDialogItem
 	PreferencesDialogItemType type;
 };
 
-G_DEFINE_TYPE(CelluloidPreferencesDialog, celluloid_preferences_dialog, GTK_TYPE_DIALOG)
+G_DEFINE_TYPE(CelluloidPreferencesDialog, celluloid_preferences_dialog, ADW_TYPE_PREFERENCES_WINDOW)
 
 static void
 file_set_handler(CelluloidFileChooserButton *button, gpointer data)
@@ -79,41 +77,11 @@ file_set_handler(CelluloidFileChooserButton *button, gpointer data)
 }
 
 static void
-response_handler(GtkDialog *dialog, gint response_id)
+save_settings(AdwPreferencesWindow *dialog)
 {
 	CelluloidPreferencesDialog *dlg = CELLULOID_PREFERENCES_DIALOG(dialog);
-
-	if(response_id == GTK_RESPONSE_ACCEPT)
-	{
-		g_settings_apply(dlg->settings);
-	}
-	else
-	{
-		g_settings_revert(dlg->settings);
-	}
-}
-
-static gboolean
-key_pressed_handler(	GtkEventControllerKey *controller,
-			guint keyval,
-			guint keycode,
-			GdkModifierType state,
-			gpointer data )
-{
-	const guint mod_mask =	GDK_MODIFIER_MASK
-				&~(GDK_SHIFT_MASK
-				|GDK_LOCK_MASK
-				|GDK_ALT_MASK
-				|GDK_SUPER_MASK
-				|GDK_HYPER_MASK
-				|GDK_META_MASK);
-
-	if((state&mod_mask) == 0 && keyval == GDK_KEY_Return)
-	{
-		gtk_dialog_response(GTK_DIALOG(data), GTK_RESPONSE_ACCEPT);
-	}
-
-	return FALSE;
+	g_settings_apply(dlg->settings);
+  gtk_window_close(dlg);
 }
 
 static void
@@ -123,18 +91,16 @@ free_signal_data(gpointer data, GClosure *closure)
 }
 
 static GtkWidget *
-build_page(const PreferencesDialogItem *items, GSettings *settings)
+build_page(const PreferencesDialogItem *items, GSettings *settings, const char *title, const char *icon_name)
 {
-	GtkWidget *grid = gtk_grid_new();
-	GSettingsSchema *schema = NULL;
+	GtkWidget *pref_page = adw_preferences_page_new();
+  adw_preferences_page_set_title(pref_page, title);
+  adw_preferences_page_set_icon_name(pref_page, icon_name);
 
-	gtk_widget_set_margin_end(grid, 12);
-	gtk_widget_set_margin_top(grid, 12);
-	gtk_widget_set_margin_bottom(grid, 12);
+  GtkWidget *pref_group = adw_preferences_group_new();
+  adw_preferences_page_add(ADW_PREFERENCES_PAGE(pref_page), ADW_PREFERENCES_GROUP(pref_group));
 
-	gtk_grid_set_row_spacing(GTK_GRID(grid), 6);
-	gtk_grid_set_column_spacing(GTK_GRID(grid), 12);
-
+  GSettingsSchema *schema = NULL;
 	g_object_get(settings, "settings-schema", &schema, NULL);
 
 	for(gint i = 0; items[i].type != ITEM_TYPE_INVALID; i++)
@@ -150,28 +116,23 @@ build_page(const PreferencesDialogItem *items, GSettings *settings)
 			NULL;
 		const gchar *label = items[i].label ?: summary;
 		const PreferencesDialogItemType type = items[i].type;
-		GtkWidget *widget = NULL;
-		gboolean separate_label = FALSE;
-		gint width = 1;
-		gint xpos = 0;
+		AdwPreferencesRow *widget = NULL;
 
-		if(type == ITEM_TYPE_GROUP)
-		{
-			widget = gtk_label_new(label);
-			width = 2;
 
-			gtk_label_set_use_markup(GTK_LABEL(widget), TRUE);
-			gtk_widget_set_halign(widget, GTK_ALIGN_START);
-			gtk_widget_set_margin_top(widget, 12);
-		}
-		else if(type == ITEM_TYPE_CHECK_BOX)
-		{
-			widget = gtk_check_button_new_with_label(label);
-			width = 2;
+		if(type == ITEM_TYPE_SWITCH)
+		{ GtkSwitch *pref_switch;
+
+			widget = adw_action_row_new();
+			adw_preferences_row_set_title(widget,label);
+
+      pref_switch = gtk_switch_new();
+      gtk_widget_set_valign(pref_switch, GTK_ALIGN_CENTER);
+      adw_action_row_add_suffix(widget, pref_switch);
+      adw_action_row_set_activatable_widget(widget, pref_switch);
 
 			g_settings_bind(	settings,
 						key,
-						widget,
+						pref_switch,
 						"active",
 						G_SETTINGS_BIND_DEFAULT );
 		}
@@ -182,19 +143,18 @@ build_page(const PreferencesDialogItem *items, GSettings *settings)
 			gchar *uri;
 			GFile *file;
 
-			widget =	celluloid_file_chooser_button_new
-					(NULL, GTK_FILE_CHOOSER_ACTION_OPEN);
+      widget = adw_action_row_new();
+      adw_preferences_row_set_title(widget,label);
 
-			button = CELLULOID_FILE_CHOOSER_BUTTON(widget);
+			button =	celluloid_file_chooser_button_new
+					(NULL, GTK_FILE_CHOOSER_ACTION_OPEN);
+      gtk_widget_set_valign(button, GTK_ALIGN_CENTER);
+      adw_action_row_add_suffix(widget, button);
+      adw_action_row_set_activatable_widget(widget, button);
+
 			filter = gtk_file_filter_new();
 			uri = g_settings_get_string(settings, key);
 			file = g_file_new_for_uri(uri);
-
-			separate_label = TRUE;
-			xpos = 1;
-
-			gtk_widget_set_hexpand(widget, TRUE);
-			gtk_widget_set_size_request(widget, 100, -1);
 
 			gtk_file_filter_add_mime_type(filter, "text/plain");
 			celluloid_file_chooser_button_set_filter(button, filter);
@@ -220,10 +180,9 @@ build_page(const PreferencesDialogItem *items, GSettings *settings)
 		}
 		else if(type == ITEM_TYPE_TEXT_BOX)
 		{
-			widget = gtk_entry_new();
-			separate_label = TRUE;
-			xpos = 1;
 
+			widget = adw_entry_row_new();
+      adw_preferences_row_set_title (widget, label);
 			gtk_widget_set_hexpand(widget, TRUE);
 
 			g_settings_bind(	settings,
@@ -232,79 +191,16 @@ build_page(const PreferencesDialogItem *items, GSettings *settings)
 						"text",
 						G_SETTINGS_BIND_DEFAULT );
 		}
-		else if(type == ITEM_TYPE_LABEL)
-		{
-			widget = gtk_label_new(label);
 
-			gtk_widget_set_halign(widget, GTK_ALIGN_START);
+    adw_preferences_group_add(pref_group, widget);
 		}
 
-		g_assert(widget);
-		g_assert(xpos == 0 || xpos == 1);
-
-		if(i == 0)
-		{
-			gtk_widget_set_margin_top(widget, 0);
-		}
-
-		if(type != ITEM_TYPE_GROUP)
-		{
-			gtk_widget_set_margin_start(widget, 12);
-		}
-
-		/* Expand the widget to fill both columns if it usually needs a
-		 * separate label but none is provided.
-		 */
-		if(separate_label && label && !label[0])
-		{
-			width = 2;
-			xpos = 0;
-		}
-
-		gtk_grid_attach(GTK_GRID(grid), widget, xpos, i, width, 1);
-
-		if(separate_label && label && label[0])
-		{
-			GtkWidget *label_widget = gtk_label_new(label);
-
-			/* The grid should only have 2 columns, so the previous
-			 * widget connot be wider than 1 column if it needs a
-			 * separate label.
-			 */
-			g_assert(width == 1);
-
-			gtk_grid_attach(	GTK_GRID(grid),
-						label_widget,
-						1-xpos, i, 1, 1 );
-
-			gtk_widget_set_halign(label_widget, GTK_ALIGN_START);
-			gtk_widget_set_hexpand(label_widget, FALSE);
-			gtk_widget_set_margin_start(label_widget, 12);
-		}
-	}
-
-	return grid;
+	return pref_page;
 }
 
 static void
 preferences_dialog_constructed(GObject *obj)
 {
-	gboolean csd_enabled;
-
-	g_object_get(obj, "use-header-bar", &csd_enabled, NULL);
-
-	if(!csd_enabled)
-	{
-		GtkWidget *content_area;
-		GtkWidget *notebook;
-
-		content_area = gtk_dialog_get_content_area(GTK_DIALOG(obj));
-		notebook = CELLULOID_PREFERENCES_DIALOG(obj)->notebook;
-
-		gtk_widget_set_margin_bottom(content_area, 12);
-		gtk_widget_set_margin_bottom(notebook, 12);
-	}
-
 	G_OBJECT_CLASS(celluloid_preferences_dialog_parent_class)->constructed(obj);
 }
 
@@ -322,7 +218,6 @@ finalize(GObject *object)
 static void
 celluloid_preferences_dialog_class_init(CelluloidPreferencesDialogClass *klass)
 {
-	GTK_DIALOG_CLASS(klass)->response = response_handler;
 	G_OBJECT_CLASS(klass)->constructed = preferences_dialog_constructed;
 	G_OBJECT_CLASS(klass)->finalize = finalize;
 }
@@ -333,45 +228,45 @@ celluloid_preferences_dialog_init(CelluloidPreferencesDialog *dlg)
 	const PreferencesDialogItem interface_items[]
 		= {	{NULL,
 			"autofit-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"csd-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"dark-theme-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"always-use-floating-controls",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"draggable-video-area-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"always-show-title-buttons",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"present-window-on-file-open",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"always-autohide-cursor",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"use-skip-buttons-for-playlist",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"last-folder-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL, NULL, ITEM_TYPE_INVALID} };
 	const PreferencesDialogItem config_items[]
 		= {	{NULL,
 			"mpv-config-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{_("mpv configuration file:"),
 			"mpv-config-file",
 			ITEM_TYPE_FILE_CHOOSER},
 			{NULL,
 			"mpv-input-config-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{_("mpv input configuration file:"),
 			"mpv-input-config-file",
 			ITEM_TYPE_FILE_CHOOSER},
@@ -379,95 +274,57 @@ celluloid_preferences_dialog_init(CelluloidPreferencesDialog *dlg)
 	const PreferencesDialogItem misc_items[]
 		= {	{NULL,
 			"always-open-new-window",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"always-append-to-playlist",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"ignore-playback-errors",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"prefetch-metadata",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"mpris-enable",
-			ITEM_TYPE_CHECK_BOX},
+			ITEM_TYPE_SWITCH},
 			{NULL,
 			"media-keys-enable",
-			ITEM_TYPE_CHECK_BOX},
-			{_("Extra mpv options:"),
-			NULL,
-			ITEM_TYPE_LABEL},
-			{"",
+			ITEM_TYPE_SWITCH},
+			{"Extra mpv Options",
 			"mpv-options",
 			ITEM_TYPE_TEXT_BOX},
 			{NULL, NULL, ITEM_TYPE_INVALID} };
 
-	GtkWidget *content_area;
-
 	dlg->settings = g_settings_new(CONFIG_ROOT);
-	dlg->notebook = gtk_notebook_new();
-	content_area = gtk_dialog_get_content_area(GTK_DIALOG(dlg));
-
 	g_settings_delay(dlg->settings);
 
-	gtk_box_append(GTK_BOX(content_area), dlg->notebook);
+	adw_preferences_window_add(	ADW_PREFERENCES_WINDOW(dlg),
+					build_page(interface_items, dlg->settings, "Interface", "preferences-desktop-appearance-symbolic"));
+	adw_preferences_window_add(	ADW_PREFERENCES_WINDOW(dlg),
+					build_page(config_items, dlg->settings, "Config Files", "document-properties-symbolic"));
+	adw_preferences_window_add(	ADW_PREFERENCES_WINDOW(dlg),
+					build_page(misc_items, dlg->settings, "Miscellaneous", "preferences-other-symbolic"));
 
-	gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook),
-					build_page(interface_items, dlg->settings),
-					gtk_label_new(_("Interface")) );
-	gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook),
-					build_page(config_items, dlg->settings),
-					gtk_label_new(_("Config Files")) );
-	gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook),
-					build_page(misc_items, dlg->settings),
-					gtk_label_new(_("Miscellaneous")) );
-	gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook),
-					celluloid_plugins_manager_new(GTK_WINDOW(dlg)),
-					gtk_label_new(_("Plugins")) );
-
-	gtk_dialog_add_buttons(	GTK_DIALOG(dlg),
-				_("_Cancel"),
-				GTK_RESPONSE_CANCEL,
-				_("_Save"),
-				GTK_RESPONSE_ACCEPT,
+	/* gtk_notebook_append_page(	GTK_NOTEBOOK(dlg->notebook), */
+	/* 				celluloid_plugins_manager_new(GTK_WINDOW(dlg)), */
+	/* 				gtk_label_new(_("Plugins")) ); */
+	g_signal_connect(	dlg,
+				"close_request",
+				G_CALLBACK(save_settings),
 				NULL );
-
-	gtk_dialog_set_default_response(GTK_DIALOG(dlg), GTK_RESPONSE_ACCEPT);
-
-	GtkEventController *key_controller = gtk_event_controller_key_new();
-
-	gtk_widget_add_controller(GTK_WIDGET(dlg), key_controller);
-
-	g_signal_connect(	key_controller,
-				"key-pressed",
-				G_CALLBACK(key_pressed_handler),
-				dlg );
 }
 
 GtkWidget *
 celluloid_preferences_dialog_new(GtkWindow *parent)
 {
 	GtkWidget *dlg;
-	GtkWidget *header_bar;
-	gboolean csd_enabled;
 
-	csd_enabled = celluloid_main_window_get_csd_enabled(CELLULOID_MAIN_WINDOW(parent));
 
 	dlg = g_object_new(	celluloid_preferences_dialog_get_type(),
 				"title", _("Preferences"),
 				"modal", TRUE,
 				"transient-for", parent,
-				"use-header-bar", csd_enabled,
 				NULL );
-
-	header_bar = gtk_dialog_get_header_bar(GTK_DIALOG(dlg));
-
-	if(header_bar)
-	{
-		gtk_header_bar_set_show_title_buttons
-			(GTK_HEADER_BAR(header_bar), FALSE);
-	}
 
 	gtk_widget_show(dlg);
 

--- a/src/celluloid-preferences-dialog.h
+++ b/src/celluloid-preferences-dialog.h
@@ -23,12 +23,13 @@
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtk.h>
+#include <adwaita.h>
 
 G_BEGIN_DECLS
 
 #define CELLULOID_TYPE_PREFERENCES_DIALOG (celluloid_preferences_dialog_get_type ())
 
-G_DECLARE_FINAL_TYPE(CelluloidPreferencesDialog, celluloid_preferences_dialog, CELLULOID, PREFERENCES_DIALOG, GtkDialog)
+G_DECLARE_FINAL_TYPE(CelluloidPreferencesDialog, celluloid_preferences_dialog, CELLULOID, PREFERENCES_DIALOG, AdwPreferencesWindow)
 
 GtkWidget *
 celluloid_preferences_dialog_new(GtkWindow *parent);


### PR DESCRIPTION
Ports the preferences-dialog to libadwaita's Preferences* widgets, putting it in line with the common GNOME preferences pattern.
![image](https://user-images.githubusercontent.com/27908024/179771984-7773f73b-09a4-4286-9ad9-b94aa52aa352.png)
![image](https://user-images.githubusercontent.com/27908024/180609768-0d3a334c-4813-4430-82d4-034057647292.png)

Notes:
- This requires a prerelease version of libadwaita due to EntryRow, so it cant be released on Flathub before GNOME 43. (at least without bundling libadwaita)
- This saves settings as the window closes. This isn't ideal - the standard is instant apply.
- ~~Plugins tab hasn't been ported over yet.~~
- ~~Plugins are now trashed instead of being deleted. I need to figure out how to show a notification allowing to untrash it, as well as handle possible errors.~~ This has been reverted since - I don't know what would be a good way to implement it.
- This ignores CSD being disabled. Unsure how supported that case is with PreferencesWindow anyway.
- There's a lot of warnings about mismatched types.
- Last but not least, I'd like to revisit and reorganise the settings design-wise. A lot of these seem either poorly explained or simply not needed.