### PR TITLE
Force scroll event controller to always operate in discrete mode

### DIFF
--- a/src/celluloid-controller-input.c
+++ b/src/celluloid-controller-input.c
@@ -341,7 +341,7 @@ celluloid_controller_input_connect_signals(CelluloidController *controller)
 
 	GtkEventController *scroll_controller =
 		gtk_event_controller_scroll_new
-		(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES);
+		(GTK_EVENT_CONTROLLER_SCROLL_BOTH_AXES | GTK_EVENT_CONTROLLER_SCROLL_DISCRETE);
 	gtk_widget_add_controller
 		(GTK_WIDGET(video_area), GTK_EVENT_CONTROLLER(scroll_controller));
 


### PR DESCRIPTION
Celluloid's scroll event handler assumes discrete scroll events, where dy (or dx) values are multiples of 1. The handler translates these events into (discrete) button press events that control volume change.

However, if supported by device, the scroll event controller might be reporting continuous scroll events by default, with dy < 1.0. With my Logitech M705 mouse, the value is a multiple of 0.125, and at normal scrolling rate, individual increments are reported. This means that the volume change is not triggered unless mouse wheel is turned at a rate where dy of individual continuous scroll events exceeds 1.0; due to physics (the high wheel turning rate required for this), this usually
means that multiple such events are generated, which precludes useful volume control.

Therefore, force the scroll event controller to always operate in the discrete mode, by setting the `GTK_EVENT_CONTROLLER_SCROLL_DISCRETE` flag on the controller.

The better use of continuous scroll events would be to generate continuous volume change events with higher granularity, but this is infeasible with current approach of triggering volume change via translated discrete button events.
