### PR TITLE
This doesn't solve building on windows yet, but it does fix an include.

### DIFF
--- a/src/celluloid-application.c
+++ b/src/celluloid-application.c
@@ -20,7 +20,9 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <glib/gprintf.h>
+#ifdef G_OS_UNIX
 #include <glib-unix.h>
+#endif
 #include <gio/gio.h>
 #include <gdk/gdk.h>
 #include <adwaita.h>
@@ -174,10 +176,11 @@ initialize_gui(CelluloidApplication *app)
 		gdk_x11_surface_set_utf8_property(surface, "WM_ROLE", app->role);
 	}
 	#endif
-
+#ifdef G_OS_UNIX
 	g_unix_signal_add(SIGHUP, shutdown_signal_handler, app);
 	g_unix_signal_add(SIGINT, shutdown_signal_handler, app);
 	g_unix_signal_add(SIGTERM, shutdown_signal_handler, app);
+#endif
 
 	g_signal_connect(	controller,
 				"notify::idle",

--- a/src/celluloid-controller.c
+++ b/src/celluloid-controller.c
@@ -21,7 +21,9 @@
 #include <glib.h>
 #include <glib/gprintf.h>
 #include <gtk/gtk.h>
+#ifdef G_OS_UNIX
 #include <glib-unix.h>
+#endif
 #include <locale.h>
 #include <adwaita.h>
 #include "celluloid-controller-private.h"

--- a/src/celluloid-mpv.c
+++ b/src/celluloid-mpv.c
@@ -38,7 +38,7 @@
 #include <epoxy/egl.h>
 #endif
 #ifdef GDK_WINDOWING_WIN32
-#include <gdk/gdkwin32.h>
+#include <gdk/win32/gdkwin32.h>
 #include <epoxy/wgl.h>
 #endif
 


### PR DESCRIPTION
The real issue if trying to compile for windows lies in celluloid-application.c and celluloid-controller.c which includes glib-unix.h which means proper code for windows needs to be cooked up for handling signals, something that I'm not confident in doing myself yet.