### PR TITLE
Fix libadwaita version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ mpv's powerful playback capabilities.
 - gcc (build)
 - glib >= 2.66
 - gtk >= 4.6.1
-- libadwaita >= 1.0.0
+- libadwaita >= 1.2.0
 - mpv >= 0.32
 - epoxy
 - lua (optional)

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ AS_IF([test "x$GLIB_GENMARSHAL" = "x"], [
 	AC_MSG_ERROR([Could not find glib-genmarshal])
 ])
 
-PKG_CHECK_MODULES(DEPS, [gtk4 >= 4.6.1 glib-2.0 >= 2.66 libadwaita-1 >= 1.0.0 mpv >= 1.107 epoxy])
+PKG_CHECK_MODULES(DEPS, [gtk4 >= 4.6.1 glib-2.0 >= 2.66 libadwaita-1 >= 1.2.0 mpv >= 1.107 epoxy])
 AC_SEARCH_LIBS([sqrt], [m])
 
 AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_66], [Dont warn using older APIs])

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,7 +131,7 @@ executable('celluloid', sources,
     libgio,
     meson.get_compiler('c').find_library('m', required: false),
     dependency('mpv', version: '>= 1.107'),
-    dependency('libadwaita-1', version: '>= 1.0.0'),
+    dependency('libadwaita-1', version: '>= 1.2.0'),
     dependency('epoxy')
   ],
   link_with: extra_libs,


### PR DESCRIPTION
The `adw_show_about_window` function introduced by https://github.com/celluloid-player/celluloid/commit/afa7d7c237a20683119aa348cece997f1c24c340 [requires libadwaita 1.2](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/func.show_about_window.html)