### PR TITLE
fix for variable size time moving seek bar

### DIFF
--- a/src/celluloid-time-label.c
+++ b/src/celluloid-time-label.c
@@ -176,8 +176,7 @@ get_max_pixel_size(GtkLabel *label, gint duration, gint *width, gint *height)
 		gchar *time_str =
 			duration < 3600 ?
 			g_strdup_printf("%02d:%02d", min_sec, min_sec) :
-			g_strdup_printf(	"%0*d:%02d:%02d",
-						hour_digits,
+			g_strdup_printf(	"%02d:%02d:%02d",
 						hour,
 						min_sec,
 						min_sec );


### PR DESCRIPTION
If the duration of the video was grater than 60 min, the variable size of the font used for the time was moving the seek bar. With this fix, it does not move. I suggest anyway the use of a monospace font if possible.