### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.celluloid_player.Celluloid.appdata.xml.in
+++ b/data/io.github.celluloid_player.Celluloid.appdata.xml.in
@@ -12,7 +12,7 @@
  <provides>
   <id>io.github.GnomeMpv.desktop</id>
  </provides>
- <description translatable="no">
+ <description translate="no">
   <p>
     Celluloid is a simple media player that can play virtually all video and
     audio formats. It supports playlists and MPRIS2 media player controls. The
@@ -30,7 +30,7 @@
  <developer_name>The Celluloid Developers</developer_name>
  <releases>
   <release date="2023-09-16" version="0.26">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -62,7 +62,7 @@
    </description>
   </release>
   <release date="2023-03-26" version="0.25">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -105,7 +105,7 @@
    </description>
   </release>
   <release date="2022-08-20" version="0.24">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -141,7 +141,7 @@
    </description>
   </release>
   <release date="2022-03-07" version="0.23">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This is mostly a bugfix release. It contains the following changes:
     </p>
@@ -168,7 +168,7 @@
    </description>
   </release>
   <release date="2021-11-05" version="0.22">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -213,7 +213,7 @@
    </description>
   </release>
   <release date="2021-03-22" version="0.21">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -248,7 +248,7 @@
    </description>
   </release>
   <release date="2020-09-19" version="0.20">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -287,7 +287,7 @@
    </description>
   </release>
   <release date="2020-04-08" version="0.19">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -340,7 +340,7 @@
    </description>
   </release>
   <release date="2019-11-05" version="0.18">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -370,7 +370,7 @@
    </description>
   </release>
   <release date="2019-08-08" version="0.17">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -409,7 +409,7 @@
    </description>
   </release>
   <release date="2019-01-21" version="0.16">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -440,7 +440,7 @@
    </description>
   </release>
   <release date="2018-09-08" version="0.15">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>
@@ -468,7 +468,7 @@
    </description>
   </release>
   <release date="2018-02-17" version="0.14">
-   <description translatable="no">
+   <description translate="no">
     <p>
      This release contains the following changes:
     </p>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html