### PR TITLE
Fix flatpak build, I think

### DIFF
--- a/flatpak/io.github.celluloid_player.Celluloid.json
+++ b/flatpak/io.github.celluloid_player.Celluloid.json
@@ -1,164 +1,403 @@
 {
-    "app-id": "io.github.celluloid_player.Celluloid",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "master",
-    "sdk": "org.gnome.Sdk",
-    "command": "celluloid",
-    "finish-args": [
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--device=all",
-        "--share=network",
-        "--socket=pulseaudio",
-        "--filesystem=xdg-pictures",
-        "--talk-name=org.gtk.vfs",
-        "--talk-name=org.gtk.vfs.*",
-        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-        "--env=LC_NUMERIC=C"
-    ],
-    "modules": [
-        {
-            "name": "luajit",
-            "no-autogen": true,
-            "cleanup": [ "/bin", "/lib/*.a", "/include", "/lib/pkgconfig", "/share/man" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
-                    "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
-                },
-                {
-                    "type": "shell",
-                    "commands": [ "sed -i 's|/usr/local|/app|' ./Makefile" ]
-                }
-            ]
-        },
-        {
-            "name": "libv4l2",
-            "cleanup": [ "/sbin", "/bin", "/include", "/lib/*.la", "/lib/*/*.la", "/lib*/*/*/*.la", "/lib/pkgconfig", "/share/man" ],
-            "config-opts": [ "--disable-static", "--disable-bpf", "--with-udevdir=/app/lib/udev" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2",
-                    "sha256": "956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
-                }
-            ]
-        },
-        {
-            "name": "nv-codec-headers",
-            "cleanup": ["*"],
-            "no-autogen": true,
-            "make-install-args": ["PREFIX=/app"],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
-                    "commit": "cf8b0b2bb70b59068b06f1d5610627c8aa6d5652"
-                }
-            ]
-        },
-        {
-            "name": "ffmpeg",
-            "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
-            "config-opts": [
-                "--enable-shared",
-                "--disable-static",
-                "--enable-gnutls",
-                "--disable-doc",
-                "--disable-programs",
-                "--disable-encoders",
-                "--disable-muxers",
-                "--enable-encoder=png",
-                "--enable-libv4l2",
-                "--enable-libdav1d"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://git.ffmpeg.org/ffmpeg.git"
-                }
-            ]
-        },
-        {
-            "name": "libass",
-            "cleanup": [ "/include", "/lib/*.la", "/lib/pkgconfig" ],
-            "config-opts": [ "--disable-static" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.xz",
-                    "sha256": "881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
-                }
-            ]
-        },
-        {
-            "name": "uchardet",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DBUILD_STATIC=0"
-            ],
-            "cleanup": [
-                "/bin",
-                "/include",
-                "/lib/pkgconfig",
-                "/share/man"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.6.tar.xz",
-                    "sha256": "8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61"
-                }
-            ]
-        },
-        {
-            "name": "libmpv",
-            "cleanup": [ "/include", "/lib/pkgconfig", "/share/man" ],
-            "buildsystem": "simple",
-            "build-commands": [
-              "python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa",
-              "python3 waf build",
-              "python3 waf install"
-            ],
-            "sources": [
-              {
-                "type": "git",
-                "url": "https://github.com/mpv-player/mpv.git"
-              },
-              {
-                "type": "file",
-                "url": "https://waf.io/waf-2.0.19",
-                "sha256": "ba63c90a865a9bcf46926c4e6776f9a3f73d29f33d49b7f61f96bc37b7397cef",
-                "dest-filename": "waf"
-              }
-            ]
-        },
-        {
-          "name": "youtube-dl",
-          "no-autogen": true,
-          "no-make-install": true,
-          "make-args": ["youtube-dl", "PYTHON=/usr/bin/python3"],
-          "post-install": ["install youtube-dl /app/bin"],
-          "sources": [{
-            "type": "git",
-            "url": "https://github.com/rg3/youtube-dl.git",
-            "tag": "2020.05.29",
-            "commit": "228c1d685bb6d35b2c1a73e1adbc085c76da6b75"
-          }]
-        },
-        {
-            "name": "celluloid",
-            "buildsystem": "meson",
-            "cleanup": ["/share/man"],
-            "sources": [
-              {
-                "type": "git",
-                "url": "https://github.com/celluloid-player/celluloid.git"
-              }
-            ]
-        }
-    ]
+   "app-id":"io.github.celluloid_player.Celluloid",
+   "runtime":"org.gnome.Platform",
+   "runtime-version":"master",
+   "sdk":"org.gnome.Sdk",
+   "command":"celluloid",
+   "finish-args":[
+      "--share=ipc",
+      "--socket=fallback-x11",
+      "--socket=wayland",
+      "--device=all",
+      "--share=network",
+      "--socket=pulseaudio",
+      "--filesystem=xdg-pictures",
+      "--talk-name=org.gtk.vfs",
+      "--talk-name=org.gtk.vfs.*",
+      "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+      "--env=LC_NUMERIC=C"
+   ],
+   "modules":[
+      {
+         "name":"luajit",
+         "no-autogen":true,
+         "cleanup":[
+            "/bin",
+            "/lib/*.a",
+            "/include",
+            "/lib/pkgconfig",
+            "/share/man"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
+               "sha256":"1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
+            },
+            {
+               "type":"shell",
+               "commands":[
+                  "sed -i 's|/usr/local|/app|' ./Makefile"
+               ]
+            }
+         ]
+      },
+      {
+         "name":"libv4l2",
+         "cleanup":[
+            "/sbin",
+            "/bin",
+            "/include",
+            "/lib/*.la",
+            "/lib/*/*.la",
+            "/lib*/*/*/*.la",
+            "/lib/pkgconfig",
+            "/share/man"
+         ],
+         "config-opts":[
+            "--disable-static",
+            "--disable-bpf",
+            "--with-udevdir=/app/lib/udev"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2",
+               "sha256":"956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7"
+            }
+         ]
+      },
+      {
+         "name":"nv-codec-headers",
+         "cleanup":[
+            "*"
+         ],
+         "no-autogen":true,
+         "make-install-args":[
+            "PREFIX=/app"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
+               "commit":"cf8b0b2bb70b59068b06f1d5610627c8aa6d5652"
+            }
+         ]
+      },
+      {
+         "name":"ffmpeg",
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig",
+            "/share/ffmpeg/examples"
+         ],
+         "config-opts":[
+            "--enable-shared",
+            "--disable-static",
+            "--enable-gnutls",
+            "--disable-doc",
+            "--disable-programs",
+            "--disable-encoders",
+            "--disable-muxers",
+            "--enable-encoder=png",
+            "--enable-libv4l2",
+            "--enable-libdav1d"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://git.ffmpeg.org/ffmpeg.git"
+            }
+         ]
+      },
+      {
+         "name":"libass",
+         "cleanup":[
+            "/include",
+            "/lib/*.la",
+            "/lib/pkgconfig"
+         ],
+         "config-opts":[
+            "--disable-static"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.xz",
+               "sha256":"881f2382af48aead75b7a0e02e65d88c5ebd369fe46bc77d9270a94aa8fd38a2"
+            }
+         ]
+      },
+      {
+         "name":"uchardet",
+         "buildsystem":"cmake-ninja",
+         "config-opts":[
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_STATIC=0"
+         ],
+         "cleanup":[
+            "/bin",
+            "/include",
+            "/lib/pkgconfig",
+            "/share/man"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.6.tar.xz",
+               "sha256":"8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61"
+            }
+         ]
+      },
+      {
+         "name":"libplacebo",
+         "buildsystem":"meson",
+         "config-opts":[
+            "-Dvulkan=enabled",
+            "-Dshaderc=enabled"
+         ],
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://github.com/haasn/libplacebo.git",
+               "mirror-urls":[
+                  "https://code.videolan.org/videolan/libplacebo.git"
+               ],
+               "tag":"v6.338.2",
+               "commit":"64c1954570f1cd57f8570a57e51fb0249b57bb90",
+               "x-checker-data":{
+                  "type":"git",
+                  "tag-pattern":"^v([\\d.]+)$"
+               }
+            }
+         ],
+         "modules":[
+            {
+               "name":"shaderc",
+               "buildsystem":"cmake-ninja",
+               "builddir":true,
+               "config-opts":[
+                  "-DSHADERC_SKIP_COPYRIGHT_CHECK=ON",
+                  "-DSHADERC_SKIP_EXAMPLES=ON",
+                  "-DSHADERC_SKIP_TESTS=ON",
+                  "-DSPIRV_SKIP_EXECUTABLES=ON",
+                  "-DENABLE_GLSLANG_BINARIES=OFF"
+               ],
+               "cleanup":[
+                  "/bin",
+                  "/include",
+                  "/lib/cmake",
+                  "/lib/pkgconfig"
+               ],
+               "sources":[
+                  {
+                     "type":"git",
+                     "url":"https://github.com/google/shaderc.git",
+                     "commit":"40bced4e1e205ecf44630d2dfa357655b6dabd04"
+                  },
+                  {
+                     "type":"git",
+                     "url":"https://github.com/KhronosGroup/SPIRV-Tools.git",
+                     "tag":"v2024.1",
+                     "commit":"04896c462d9f3f504c99a4698605b6524af813c1",
+                     "dest":"third_party/spirv-tools"
+                  },
+                  {
+                     "type":"git",
+                     "url":"https://github.com/KhronosGroup/SPIRV-Headers.git",
+                     "commit":"4f7b471f1a66b6d06462cd4ba57628cc0cd087d7",
+                     "dest":"third_party/spirv-headers"
+                  },
+                  {
+                     "type":"git",
+                     "url":"https://github.com/KhronosGroup/glslang.git",
+                     "tag":"14.2.0",
+                     "commit":"e8dd0b6903b34f1879520b444634c75ea2deedf5",
+                     "dest":"third_party/glslang",
+                     "x-checker-data":{
+                        "type":"git",
+                        "tag-pattern":"^(\\d{1,2}\\.\\d{1,2}\\.\\d{1,4})$"
+                     }
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "name":"libcdio",
+         "config-opts":[
+            "--disable-static",
+            "--disable-example-progs"
+         ],
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2",
+               "mirror-urls":[
+                  "https://mirrors.kernel.org/gnu/libcdio/libcdio-2.1.0.tar.bz2",
+                  "https://mirrors.ocf.berkeley.edu/gnu/libcdio/libcdio-2.1.0.tar.bz2",
+                  "https://ftpmirror.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2"
+               ],
+               "sha256":"8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b",
+               "x-checker-data":{
+                  "type":"html",
+                  "url":"https://ftp.gnu.org/gnu/libcdio/",
+                  "version-pattern":"libcdio-(\\d\\.\\d+\\.?\\d*).tar.bz2",
+                  "url-template":"https://ftp.gnu.org/gnu/libcdio/libcdio-$version.tar.bz2"
+               }
+            }
+         ]
+      },
+      {
+         "name":"libcdio-paranoia",
+         "config-opts":[
+            "--disable-static",
+            "--disable-example-progs"
+         ],
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2",
+               "mirror-urls":[
+                  "https://mirrors.kernel.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2",
+                  "https://mirrors.ocf.berkeley.edu/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2",
+                  "https://ftpmirror.gnu.org/gnu/libcdio/libcdio-paranoia-10.2+2.0.1.tar.bz2"
+               ],
+               "sha256":"33b1cf305ccfbfd03b43936975615000ce538b119989c4bec469577570b60e8a",
+               "x-checker-data":{
+                  "type":"html",
+                  "url":"https://ftp.gnu.org/gnu/libcdio/",
+                  "version-pattern":"libcdio-paranoia-([\\d\\.\\+-]+).tar.bz2",
+                  "url-template":"https://ftp.gnu.org/gnu/libcdio/libcdio-paranoia-$version.tar.bz2"
+               }
+            }
+         ]
+      },
+      {
+         "name":"libdvdread",
+         "config-opts":[
+            "--disable-static"
+         ],
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://download.videolan.org/pub/videolan/libdvdread/6.1.3/libdvdread-6.1.3.tar.bz2",
+               "mirror-urls":[
+                  "https://videolan.mirror.ba/libdvdread/6.1.3/libdvdread-6.1.3.tar.bz2",
+                  "https://videolan.c3sl.ufpr.br/libdvdread/6.1.3/libdvdread-6.1.3.tar.bz2"
+               ],
+               "sha256":"ce35454997a208cbe50e91232f0e73fb1ac3471965813a13b8730a8f18a15369",
+               "x-checker-data":{
+                  "type":"html",
+                  "url":"https://www.videolan.org/developers/libdvdnav.html",
+                  "version-pattern":"The latest version of <code>libdvdread</code> is <b>([\\d\\-\\.]+)<",
+                  "url-template":"https://download.videolan.org/pub/videolan/libdvdread/$version/libdvdread-$version.tar.bz2"
+               }
+            }
+         ]
+      },
+      {
+         "name":"libdvdnav",
+         "config-opts":[
+            "--disable-static"
+         ],
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://download.videolan.org/pub/videolan/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2",
+               "mirror-urls":[
+                  "https://videolan.mirror.ba/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2",
+                  "https://videolan.c3sl.ufpr.br/libdvdnav/6.1.1/libdvdnav-6.1.1.tar.bz2"
+               ],
+               "sha256":"c191a7475947d323ff7680cf92c0fb1be8237701885f37656c64d04e98d18d48",
+               "x-checker-data":{
+                  "type":"html",
+                  "url":"https://www.videolan.org/developers/libdvdnav.html",
+                  "version-pattern":"The latest version of <code>libdvdnav</code> is <b>([\\d\\-\\.]+)</b>\\.",
+                  "url-template":"https://download.videolan.org/pub/videolan/libdvdnav/$version/libdvdnav-$version.tar.bz2"
+               }
+            }
+         ]
+      },
+      {
+         "name":"libmpv",
+         "cleanup":[
+            "/include",
+            "/lib/pkgconfig",
+            "/share/man"
+         ],
+         "buildsystem":"meson",
+         "config-opts":[
+            "-Dbuild-date=false",
+            "-Dlibmpv=true",
+            "-Dmanpage-build=disabled",
+            "-Dcdda=enabled",
+            "-Ddvbin=enabled",
+            "-Ddvdnav=enabled",
+            "-Dlibarchive=enabled",
+            "-Dsdl2=enabled",
+            "-Dvulkan=enabled",
+            "-Dvulkan-interop=enabled"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://github.com/mpv-player/mpv.git"
+            }
+         ]
+      },
+      {
+         "name":"youtube-dl",
+         "no-autogen":true,
+         "no-make-install":true,
+         "make-args":[
+            "youtube-dl",
+            "PYTHON=/usr/bin/python3"
+         ],
+         "post-install":[
+            "install youtube-dl /app/bin"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://github.com/rg3/youtube-dl.git",
+               "tag":"2020.05.29",
+               "commit":"228c1d685bb6d35b2c1a73e1adbc085c76da6b75"
+            }
+         ]
+      },
+      {
+         "name":"celluloid",
+         "buildsystem":"meson",
+         "cleanup":[
+            "/share/man"
+         ],
+         "sources":[
+            {
+               "type":"git",
+               "url":"https://github.com/celluloid-player/celluloid.git"
+            }
+         ]
+      }
+   ]
 }


### PR DESCRIPTION
mpv has dropped Waf build support some time ago, making the Celluloid build fail. This switches to use meson, as well as pulls some mpv dependencies.