### PR TITLE
control-box: Remove broken CSS

### DIFF
--- a/src/celluloid-control-box.c
+++ b/src/celluloid-control-box.c
@@ -773,15 +773,6 @@ celluloid_control_box_init(CelluloidControlBox *box)
 
 	g_object_set(box, "orientation", GTK_ORIENTATION_VERTICAL, NULL);
 
-	gchar css_data[] = "box {border-spacing: 0px;}";
-	GtkCssProvider *css = gtk_css_provider_new();
-	gtk_css_provider_load_from_data(css, css_data, -1);
-
-	gtk_style_context_add_provider_for_display
-		(	gtk_widget_get_display(GTK_WIDGET(box)),
-			GTK_STYLE_PROVIDER(css),
-			GTK_STYLE_PROVIDER_PRIORITY_USER );
-
 	box->inner_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
 	gtk_box_append(GTK_BOX(box), box->secondary_seek_bar);


### PR DESCRIPTION
It doesn't seem to do anything here, but it breaks stuff elsewhere, notably in Preferences and AboutWindow.
Before:
![image](https://github.com/celluloid-player/celluloid/assets/27908024/a741690f-16f8-4892-873b-cf2ad0754094)
![image](https://github.com/celluloid-player/celluloid/assets/27908024/c2a63a3e-79cb-4039-a037-99c9209530ff)
![image](https://github.com/celluloid-player/celluloid/assets/27908024/cfbc7a37-709b-4d8d-a5fe-3cba6eeead26)
After:
![image](https://github.com/celluloid-player/celluloid/assets/27908024/da564924-3f92-487a-96b6-579f738f406a)

![image](https://github.com/celluloid-player/celluloid/assets/27908024/b1033ca1-e80e-4181-a275-cd5ab78f511c)
![image](https://github.com/celluloid-player/celluloid/assets/27908024/189d79e2-ca30-4b0e-bdef-923b28435aa8)

