### PR TITLE
mpv: Prevent blocking in the render update callback for vo=libmpv

### DIFF
--- a/src/celluloid-mpv.c
+++ b/src/celluloid-mpv.c
@@ -435,6 +435,13 @@ initialize(CelluloidMpv *mpv)
 	{
 		g_info("Forcing --vo=libmpv");
 		mpv_set_option_string(priv->mpv_ctx, "vo", "libmpv");
+
+		// According to the libmpv documentation (https://www.ccoderun.ca/programming/doxygen/mpv/render_8h.html#aad9f0d390bf1e49242b9cfe813264314),
+		// the render update callback will block before the value of video-timing-offset (default 0.050s).
+		// This significantly reduces smoothness at low frame rates. Setting it to 0 can fix this issue.
+		mpv_set_option_string(priv->mpv_ctx, "video-timing-offset", "0");
+		// According to the documentation, when setting this property, we also need to set video-sync=audio.
+		mpv_set_option_string(priv->mpv_ctx, "video-sync", "audio");
 	}
 
 	mpv_set_wakeup_callback(priv->mpv_ctx, wakeup_callback, mpv);


### PR DESCRIPTION
According to the [documentation](https://www.ccoderun.ca/programming/doxygen/mpv/render_8h.html#aad9f0d390bf1e49242b9cfe813264314), setting video-timing-offset to 0 prevents blocking during render updates.
This has a noticeable effect on improving the software frame rate on wayland.

![photo_2024-09-29_07-51-26](https://github.com/user-attachments/assets/849a8bb8-2c0b-43fb-b284-be1b3436779b)
