### PR TITLE
main-window: Calculate size offset on allocation

### DIFF
--- a/src/celluloid-main-window.c
+++ b/src/celluloid-main-window.c
@@ -279,8 +279,12 @@ notify(GObject *object, GParamSpec *pspec)
 static void
 size_allocate(GtkWidget *widget, gint width, gint height, gint baseline)
 {
+	CelluloidMainWindowPrivate *priv = get_private(widget);
+
 	GTK_WIDGET_CLASS(celluloid_main_window_parent_class)
 		->size_allocate(widget, width, height, baseline);
+
+	celluloid_video_area_get_offset((CelluloidVideoArea*)priv->video_area, &priv->width_offset, &priv->height_offset);
 }
 
 static void

--- a/src/celluloid-video-area.c
+++ b/src/celluloid-video-area.c
@@ -811,3 +811,20 @@ celluloid_video_area_get_xid(CelluloidVideoArea *area)
 
 	return -1;
 }
+
+void
+celluloid_video_area_get_offset(CelluloidVideoArea *area, gint *width, gint *height)
+{
+	GtkAllocation allocation;
+
+	*width = 0;
+	*height = 0;
+
+	gtk_widget_get_allocation((GtkWidget*)area, &allocation);
+	*width = allocation.width;
+	*height = allocation.height;
+
+	gtk_widget_get_allocation(area->stack, &allocation);
+	*width -= allocation.width;
+	*height -= allocation.height;
+}

--- a/src/celluloid-video-area.h
+++ b/src/celluloid-video-area.h
@@ -93,4 +93,7 @@ celluloid_video_area_get_control_box(CelluloidVideoArea *area);
 gint64
 celluloid_video_area_get_xid(CelluloidVideoArea *area);
 
+void
+celluloid_video_area_get_offset(CelluloidVideoArea *area, gint *width, gint *height);
+
 #endif


### PR DESCRIPTION
This fixes an issue where the window is resized to that of the video, then resized again to that of the video and decoration.

It does this by setting the main window `height_offset` to the difference between the size of the video and the video area. I'm not sure whether to remove modification of this value in `resize_video_area_finalize`, setting it during `size-allocation` may solve the problem it was initially created for.

### `master` branch
https://github.com/user-attachments/assets/5ffbf586-0722-4e0d-8517-f283d780a05c
### this branch
https://github.com/user-attachments/assets/cd07436f-d987-4b54-895f-2fb97b8679f2