### PR TITLE
Use GtkGraphicsOffload for direct scanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Repository Mirror: https://codeberg.org/celluloid-player/celluloid
 - pkg-config (build)
 - gcc (build)
 - glib >= 2.66
-- gtk >= 4.10
+- gtk >= 4.16
 - libadwaita >= 1.6.0
 - mpv >= 0.32
 - epoxy

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ AS_IF([test "x$GLIB_GENMARSHAL" = "x"], [
 	AC_MSG_ERROR([Could not find glib-genmarshal])
 ])
 
-PKG_CHECK_MODULES(DEPS, [gtk4 >= 4.10.0 glib-2.0 >= 2.66 libadwaita-1 >= 1.6.0 mpv >= 1.107 epoxy])
+PKG_CHECK_MODULES(DEPS, [gtk4 >= 4.16.0 glib-2.0 >= 2.66 libadwaita-1 >= 1.6.0 mpv >= 1.107 epoxy])
 AC_SEARCH_LIBS([sqrt], [m])
 
 AC_DEFINE([ADW_VERSION_MIN_REQUIRED], [ADW_VERSION_1_6], [Dont warn using older APIs])
@@ -99,8 +99,8 @@ AC_DEFINE([ADW_VERSION_MAX_ALLOWED], [ADW_VERSION_1_6], [Prevents using newer AP
 AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_66], [Dont warn using older APIs])
 AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_66], [Prevents using newer APIs])
 
-AC_DEFINE([GDK_VERSION_MIN_REQUIRED], [GDK_VERSION_4_10], [Dont warn using older APIs])
-AC_DEFINE([GDK_VERSION_MAX_ALLOWED], [GDK_VERSION_4_10], [Prevents using newer APIs])
+AC_DEFINE([GDK_VERSION_MIN_REQUIRED], [GDK_VERSION_4_16], [Dont warn using older APIs])
+AC_DEFINE([GDK_VERSION_MAX_ALLOWED], [GDK_VERSION_4_16], [Prevents using newer APIs])
 
 AC_DEFINE_UNQUOTED([G_LOG_DOMAIN], "$PACKAGE_NAME", [Default logging facility])
 

--- a/src/celluloid-video-area.c
+++ b/src/celluloid-video-area.c
@@ -47,6 +47,7 @@ struct _CelluloidVideoArea
 	GtkWidget *toast_overlay;
 	GtkWidget *stack;
 	GtkWidget *gl_area;
+	GtkWidget *graphics_offload;
 	GtkWidget *toolbar_view;
 	GtkWidget *initial_page;
 	GtkWidget *control_box;
@@ -444,6 +445,7 @@ celluloid_video_area_init(CelluloidVideoArea *area)
 	area->toast_overlay = adw_toast_overlay_new();
 	area->stack = gtk_stack_new();
 	area->gl_area = gtk_gl_area_new();
+	area->graphics_offload = gtk_graphics_offload_new(area->gl_area);
 	area->toolbar_view = adw_toolbar_view_new();
 	area->initial_page = adw_status_page_new();
 	area->control_box = celluloid_control_box_new();
@@ -561,11 +563,13 @@ celluloid_video_area_init(CelluloidVideoArea *area)
 		(	ADW_STATUS_PAGE(area->initial_page),
 			"io.github.celluloid_player.Celluloid" );
 
-	gtk_stack_add_child(GTK_STACK(area->stack), area->gl_area);
+	gtk_stack_add_child(GTK_STACK(area->stack), area->graphics_offload);
 	gtk_stack_add_child(GTK_STACK(area->stack), area->initial_page);
 
 	celluloid_video_area_set_status
 		(area, CELLULOID_VIDEO_AREA_STATUS_LOADING);
+
+	gtk_graphics_offload_set_black_background(GTK_GRAPHICS_OFFLOAD(area->graphics_offload), TRUE);
 
 	gtk_widget_set_hexpand(area->stack, TRUE);
 
@@ -702,7 +706,7 @@ celluloid_video_area_set_status(	CelluloidVideoArea *area,
 
 		case CELLULOID_VIDEO_AREA_STATUS_PLAYING:
 		gtk_stack_set_visible_child
-			(GTK_STACK(area->stack), area->gl_area);
+			(GTK_STACK(area->stack), area->graphics_offload);
 		break;
 	}
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,7 +48,7 @@ sources += custom_target('authors',
   ]
 )
 
-libgtk = dependency('gtk4', version: '>=4.10.0')
+libgtk = dependency('gtk4', version: '>=4.16.0')
 localedir = join_paths(get_option('prefix'), get_option('localedir'))
 cflags = [
   '-DG_SETTINGS_ENABLE_BACKEND',
@@ -60,8 +60,8 @@ cflags = [
   '-DADW_VERSION_MAX_ALLOWED=ADW_VERSION_1_6',
   '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_66',
   '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_66',
-  '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_10',
-  '-DGDK_VERSION_MAX_ALLOWED=GDK_VERSION_4_10'
+  '-DGDK_VERSION_MIN_REQUIRED=GDK_VERSION_4_16',
+  '-DGDK_VERSION_MAX_ALLOWED=GDK_VERSION_4_16'
 ]
 
 if get_option('buildtype') == 'release'


### PR DESCRIPTION
This also bumps the minimum GTK version to the latest stable version `4.16` for support for `gtk_graphics_offload_set_black_background` which increases the probability that it achieves direct scanout.

| Before 80% CPU utilization | After 20% CPU utilization |
| - | - |
| ![Screenshot From 2025-02-13 11-21-36](https://github.com/user-attachments/assets/ff2d092b-c539-4aee-89f9-1b77e4b3ee79) | ![Screenshot From 2025-02-13 11-19-49](https://github.com/user-attachments/assets/115f6ee1-29e0-4d4d-a609-647ca26b2d54) |

The pink boarders are a debug feature to indicate direct scanout and switched on in the GTK inspector.

Since this bumps the GTK version there are a few extra deprecation warning I've not tackled.

This is related to https://github.com/celluloid-player/celluloid/issues/927