### PR TITLE
meson: Compile settings schemas for debugging

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -56,3 +56,6 @@ if glib_compile_schemas.found()
     args: ['--strict', '--dry-run', meson.current_source_dir()]
   )
 endif
+
+# Compile schemas for devenv etc.
+gnome.compile_schemas()


### PR DESCRIPTION
This allows a developer to compile and run a build using meson devenv.

```bash
meson setup ./_build
meson compile -C ./_build
meson devenv -C ./_build
celluloid
```

`meson compile` will compile the schema to `./_build/data/gschema.compiled` and `meson devenv` sets `GSETTINGS_SCHEMA_DIR` to that directory.