### PR TITLE
player: Disconnect GVolumeMonitor signals

### DIFF
--- a/src/celluloid-player.c
+++ b/src/celluloid-player.c
@@ -262,6 +262,8 @@ dispose(GObject *object)
 {
 	CelluloidPlayerPrivate *priv = get_private(object);
 
+	g_signal_handlers_disconnect_by_data(priv->monitor, object);
+
 	g_clear_object(&priv->cache);
 	g_clear_object(&priv->monitor);
 


### PR DESCRIPTION
This fixes a SIGSEGV when the "volume-removed" handler is called on a window that has been closed.

### Steps to Reproduce
* Opening two celluloid windows
* Closing one
* Mount a volume (plug in a USB drive)
* Unmount the volume
* Celluloid will SIGSEGV

I'm seeing the construction API is `g_volume_monitor_get` which suggests the object outlives the provided reference. Which would explain why the signal is still firing.

This could be an upstream issue.