### PR TITLE
Make idle inhibition per window rather than app

### DIFF
--- a/src/celluloid-controller-private.h
+++ b/src/celluloid-controller-private.h
@@ -59,6 +59,7 @@ struct _CelluloidController
 	GBinding *skip_buttons_binding;
 	GSettings *settings;
 	CelluloidMpris *mpris;
+	guint inhibit_cookie;
 };
 
 struct _CelluloidControllerClass


### PR DESCRIPTION
This was causing rare from GTK validating closed windows. 

The crash happened in [`gdk_wayland_toplevel_inhibit_idle`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/wayland/gdktoplevel-wayland.c?ref_type=heads#L2489) as it failed to assert that the given toplevel was a toplevel, I  assume this was a result of a cookie related to a previously closed window being uninhibited.

You can test the inhibition state in gnome with  `watch -n 0.3 gnome-session-inhibit --list`

### Reproducing
1. Launch celluloid
2. Open media in new window
3. Close media window while playing
4. Open media in new window and notice error
```
(io.github.celluloid_player.Celluloid:515804): Gdk-CRITICAL **: 00:00:49.113: gdk_wayland_toplevel_uninhibit_idle: assertion 'GDK_IS_WAYLAND_TOPLEVEL (toplevel)' failed
```
6. Repeat 3 and 4 until `SIGSEGV`