### PR TITLE
controller: Check model is not NULL on notify::is-active

### DIFF
--- a/src/celluloid-controller.c
+++ b/src/celluloid-controller.c
@@ -571,6 +571,8 @@ is_active_handler(GObject *gobject, GParamSpec *pspec, gpointer data)
 	CelluloidView *view = CELLULOID_VIEW(gobject);
 	gboolean is_active = TRUE;
 
+	g_return_if_fail(controller->model);
+
 	g_object_get(view, "is-active", &is_active, NULL);
 
 	if(!is_active)


### PR DESCRIPTION
For some reason with GTK 4.17.4 this causes a NULL dereference on window close.

I have investigated why this happens yet, there may be a better fix.