### PR TITLE
Run mpv in advanced control mode

### DIFF
--- a/src/celluloid-metadata-cache.c
+++ b/src/celluloid-metadata-cache.c
@@ -147,8 +147,10 @@ mpv_event_notify(	CelluloidMpv *mpv,
 		CelluloidMetadataCacheEntry *entry = NULL;
 		gchar *path = NULL;
 
+		/*
 		celluloid_mpv_get_property
 			(mpv, "path", MPV_FORMAT_STRING, &path);
+			*/
 
 		if(path)
 		{
@@ -163,6 +165,7 @@ mpv_event_notify(	CelluloidMpv *mpv,
 			gchar *media_title = NULL;
 			mpv_node metadata;
 
+/*
 			celluloid_mpv_get_property(	mpv,
 							"duration",
 							MPV_FORMAT_DOUBLE,
@@ -175,7 +178,7 @@ mpv_event_notify(	CelluloidMpv *mpv,
 							"metadata",
 							MPV_FORMAT_NODE,
 							&metadata );
-
+*/
 			if(!entry->title)
 			{
 				entry->title = g_strdup(media_title);

--- a/src/celluloid-model.c
+++ b/src/celluloid-model.c
@@ -49,6 +49,7 @@ enum
 	PROP_WINDOW_MAXIMIZED,
 	PROP_WINDOW_SCALE,
 	PROP_DISPLAY_FPS,
+	PROP_TIME_POS,
 	N_PROPERTIES
 };
 
@@ -81,6 +82,7 @@ struct _CelluloidModel
 	gboolean window_maximized;
 	gdouble window_scale;
 	gdouble display_fps;
+	gdouble time_pos;
 	GStrv input_binding_list;
 };
 
@@ -310,6 +312,10 @@ set_property(	GObject *object,
 		self->display_fps = g_value_get_double(value);
 		break;
 
+		case PROP_TIME_POS:
+		self->time_pos = g_value_get_double(value);
+		break;
+
 		default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
 		break;
@@ -419,6 +425,10 @@ get_property(	GObject *object,
 
 		case PROP_DISPLAY_FPS:
 		g_value_set_double(value, self->display_fps);
+		break;
+
+		case PROP_TIME_POS:
+		g_value_set_double(value, self->time_pos);
 		break;
 
 		default:
@@ -565,6 +575,13 @@ set_mpv_property(	GObject *object,
 						"display-fps",
 						MPV_FORMAT_DOUBLE,
 						&self->display_fps );
+		break;
+
+		case PROP_TIME_POS:
+		celluloid_mpv_set_property(	mpv,
+						"time-pos",
+						MPV_FORMAT_DOUBLE,
+						&self->time_pos );
 		break;
 	}
 }
@@ -715,6 +732,7 @@ build_input_binding_list(CelluloidMpv *mpv)
 	mpv_node bindings_node = {0};
 	mpv_node_list *bindings_array = NULL;
 
+	return NULL;
 	const gint err =
 		celluloid_mpv_get_property
 		(	mpv,
@@ -809,6 +827,7 @@ celluloid_model_class_init(CelluloidModelClass *klass)
 			{"volume-max", PROP_VOLUME_MAX, G_TYPE_DOUBLE},
 			{"window-maximized", PROP_WINDOW_MAXIMIZED, G_TYPE_BOOLEAN},
 			{"window-scale", PROP_WINDOW_SCALE, G_TYPE_DOUBLE},
+			{"time-pos", PROP_TIME_POS, G_TYPE_DOUBLE},
 			{NULL, PROP_INVALID, 0} };
 
 	GObjectClass *obj_class = G_OBJECT_CLASS(klass);
@@ -896,6 +915,7 @@ celluloid_model_init(CelluloidModel *model)
 	model->window_maximized = FALSE;
 	model->window_scale = 1.0;
 	model->display_fps = 0.0;
+	model->time_pos = 0.0;
 	model->input_binding_list = NULL;
 }
 
@@ -940,9 +960,10 @@ celluloid_model_initialize(CelluloidModel *model)
 		CelluloidMpv *mpv =
 			CELLULOID_MPV(model);
 		gboolean shuffle =
-			celluloid_mpv_get_property_flag(mpv, "shuffle");
+			false;
+		//	celluloid_mpv_get_property_flag(mpv, "shuffle");
 
-		g_object_set(model, "shuffle", shuffle, NULL);
+		//g_object_set(model, "shuffle", shuffle, NULL);
 	}
 
 	if(extra_options_contains(model, "loop-playlist"))
@@ -950,12 +971,12 @@ celluloid_model_initialize(CelluloidModel *model)
 		// Sync the property to match mpv's
 		CelluloidMpv *mpv =
 			CELLULOID_MPV(model);
-		gchar *loop_playlist =
+		/*gchar *loop_playlist =
 			celluloid_mpv_get_property_string(mpv, "loop-playlist");
 
 		g_object_set(model, "loop-playlist", loop_playlist, NULL);
 
-		mpv_free(loop_playlist);
+		mpv_free(loop_playlist);*/
 	}
 	else
 	{
@@ -1175,18 +1196,8 @@ celluloid_model_load_subtitle_track(	CelluloidModel *model,
 gdouble
 celluloid_model_get_time_position(CelluloidModel *model)
 {
-	gdouble time_pos = 0.0;
-
-	if(!model->idle_active)
-	{
-		celluloid_mpv_get_property(	CELLULOID_MPV(model),
-						"time-pos",
-						MPV_FORMAT_DOUBLE,
-						&time_pos );
-	}
-
 	/* time-pos may become negative during seeks */
-	return MAX(0, time_pos);
+	return MAX(0, model->time_pos);
 }
 
 void
@@ -1276,18 +1287,23 @@ celluloid_model_get_video_geometry(	CelluloidModel *model,
 {
 	CelluloidMpv *mpv = CELLULOID_MPV(model);
 
+	/*
 	celluloid_mpv_get_property(mpv, "dwidth", MPV_FORMAT_INT64, width);
 	celluloid_mpv_get_property(mpv, "dheight", MPV_FORMAT_INT64, height);
+	*/
 }
 
 gchar *
 celluloid_model_get_current_path(CelluloidModel *model)
 {
 	CelluloidMpv *mpv = CELLULOID_MPV(model);
+	/*
 	gchar *path = celluloid_mpv_get_property_string(mpv, "path");
 	gchar *buf = g_strdup(path);
 
 	mpv_free(path);
 
 	return buf;
+	*/
+	return NULL;
 }

--- a/src/celluloid-mpv.c
+++ b/src/celluloid-mpv.c
@@ -472,16 +472,16 @@ load_file(CelluloidMpv *mpv, const gchar *uri, gboolean append)
 	g_assert(uri);
 	g_info(	"Loading file (append=%s): %s", append?"TRUE":"FALSE", uri);
 
-	mpv_get_property(	priv->mpv_ctx,
+	/*mpv_get_property(	priv->mpv_ctx,
 				"playlist-count",
 				MPV_FORMAT_INT64,
 				&playlist_count );
-
+*/
 	load_cmd[2] = (append && playlist_count > 0)?"append":"replace";
 
 	if(!append)
 	{
-		celluloid_mpv_set_property_flag(mpv, "pause", FALSE);
+		//celluloid_mpv_set_property_flag(mpv, "pause", FALSE);
 	}
 
 	g_assert(priv->mpv_ctx);
@@ -498,15 +498,17 @@ reset(CelluloidMpv *mpv)
 	CelluloidMpvPrivate *priv = get_private(mpv);
 	gchar *loop_file_str;
 	gchar *loop_playlist_str;
-	gboolean loop_file;
-	gboolean loop_playlist;
+	gboolean loop_file = TRUE;
+	gboolean loop_playlist = TRUE;
 
+	/*
 	loop_file_str =		celluloid_mpv_get_property_string
 				(mpv, "loop-file");
 	loop_playlist_str =	celluloid_mpv_get_property_string
 				(mpv, "loop-playlist");
 	loop_file =		(g_strcmp0(loop_file_str, "inf") == 0);
 	loop_playlist =		(g_strcmp0(loop_playlist_str, "inf") == 0);
+	*/
 
 	mpv_free(loop_file_str);
 	mpv_free(loop_playlist_str);
@@ -716,6 +718,7 @@ celluloid_mpv_init_gl(CelluloidMpv *mpv)
 			{MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &init_params},
 			{MPV_RENDER_PARAM_WL_DISPLAY, get_wl_display()},
 			{MPV_RENDER_PARAM_X11_DISPLAY, get_x11_display()},
+			{MPV_RENDER_PARAM_ADVANCED_CONTROL, &(int){1}},
 			{0, NULL} };
 	gint rc = mpv_render_context_create(	&priv->render_ctx,
 						priv->mpv_ctx,

--- a/src/celluloid-player-options.c
+++ b/src/celluloid-player-options.c
@@ -249,12 +249,12 @@ static gboolean
 get_video_dimensions(CelluloidMpv *mpv, gint64 dim[2])
 {
 	gint rc = 0;
-
+/*
 	rc |=	celluloid_mpv_get_property
 		(mpv, "dwidth", MPV_FORMAT_INT64, &dim[0]);
 	rc |=	celluloid_mpv_get_property
 		(mpv, "dheight", MPV_FORMAT_INT64, &dim[1]);
-
+*/
 	return (rc >= 0);
 }
 
@@ -296,13 +296,15 @@ autofit_handler(CelluloidMpv *mpv, gpointer data)
 static gboolean
 handle_window_scale(CelluloidMpv *mpv, gint64 dim[2])
 {
-	gchar *scale_str;
-	gboolean scale_set;
+	gchar *scale_str = NULL;
+	gboolean scale_set = FALSE;
 
+	/*
 	scale_str =	celluloid_mpv_get_property_string
 			(mpv, "options/window-scale");
-	scale_set = scale_str && *scale_str;
+	scale_set = scale_str && *scale_str;*/
 
+	mpv_free(scale_str);
 	if(scale_set)
 	{
 		gdouble scale;
@@ -315,9 +317,9 @@ handle_window_scale(CelluloidMpv *mpv, gint64 dim[2])
 		scale = g_ascii_strtod(scale_str, NULL);
 		dim[0] = (gint64)(scale*(gdouble)dim[0]);
 		dim[1] = (gint64)(scale*(gdouble)dim[1]);
+		mpv_free(scale_str);
 	}
 
-	mpv_free(scale_str);
 
 	return scale_set;
 }
@@ -335,14 +337,14 @@ handle_autofit(CelluloidMpv *mpv, gint64 dim[2], GdkRectangle monitor_geom)
 	gboolean larger_set = FALSE;
 	gboolean smaller_set = FALSE;
 	gboolean updated = FALSE;
-
+/*
 	autofit_str =	celluloid_mpv_get_property_string
 			(mpv, "options/autofit");
 	larger_str =	celluloid_mpv_get_property_string
 			(mpv, "options/autofit-larger");
 	smaller_str =	celluloid_mpv_get_property_string
 			(mpv, "options/autofit-smaller");
-
+*/
 	autofit_set = autofit_str && *autofit_str;
 	larger_set = larger_str && *larger_str;
 	smaller_set = smaller_str && *smaller_str;
@@ -398,8 +400,11 @@ handle_autofit(CelluloidMpv *mpv, gint64 dim[2], GdkRectangle monitor_geom)
 static void
 handle_geometry(CelluloidPlayer *player, GdkRectangle monitor_geom)
 {
+	gchar *geometry_str = NULL;
+	/*
 	gchar *geometry_str =	celluloid_mpv_get_property_string
 				(CELLULOID_MPV(player), "options/geometry");
+	*/
 
 	if(geometry_str)
 	{
@@ -424,9 +429,8 @@ handle_geometry(CelluloidPlayer *player, GdkRectangle monitor_geom)
 						"window-resize",
 						dim[0], dim[1] );
 		}
+		mpv_free(geometry_str);
 	}
-
-	mpv_free(geometry_str);
 }
 
 static void
@@ -437,23 +441,23 @@ handle_msg_level(CelluloidPlayer *player)
 	gchar **tokens = NULL;
 	gint i;
 
-	optbuf = celluloid_mpv_get_property_string(mpv, "options/msg-level");
+	//optbuf = celluloid_mpv_get_property_string(mpv, "options/msg-level");
 
 	if(optbuf)
 	{
 		tokens = g_strsplit(optbuf, ",", 0);
+
+		for(i = 0; tokens && tokens[i]; i++)
+		{
+			gchar **pair = g_strsplit(tokens[i], "=", 2);
+
+			celluloid_player_set_log_level(player, pair[0], pair[1]);
+			g_strfreev(pair);
+		}
+
+		mpv_free(optbuf);
+		g_strfreev(tokens);
 	}
-
-	for(i = 0; tokens && tokens[i]; i++)
-	{
-		gchar **pair = g_strsplit(tokens[i], "=", 2);
-
-		celluloid_player_set_log_level(player, pair[0], pair[1]);
-		g_strfreev(pair);
-	}
-
-	mpv_free(optbuf);
-	g_strfreev(tokens);
 }
 
 void

--- a/src/celluloid-player.c
+++ b/src/celluloid-player.c
@@ -310,10 +310,12 @@ mpv_event_notify(CelluloidMpv *mpv, gint event_id, gpointer event_data)
 	{
 		gboolean vo_configured = FALSE;
 
+		/*
 		celluloid_mpv_get_property(	mpv,
 					"vo-configured",
 					MPV_FORMAT_FLAG,
 					&vo_configured );
+					*/
 
 		/* If the vo is not configured yet, save the content of mpv's
 		 * playlist. This will be loaded again when the vo is
@@ -426,8 +428,10 @@ mpv_property_changed(CelluloidMpv *mpv, const gchar *name, gpointer value)
 		gboolean idle_active = FALSE;
 		gboolean pause = value?*((int *)value):TRUE;
 
+		/*
 		celluloid_mpv_get_property
 			(mpv, "idle-active", MPV_FORMAT_FLAG, &idle_active);
+		*/
 
 		if(idle_active && !pause && !priv->init_vo_config)
 		{
@@ -439,8 +443,10 @@ mpv_property_changed(CelluloidMpv *mpv, const gchar *name, gpointer value)
 		gboolean idle_active = FALSE;
 		gboolean was_empty = FALSE;
 
+		/*
 		celluloid_mpv_get_property
 			(mpv, "idle-active", MPV_FORMAT_FLAG, &idle_active);
+		*/
 
 		was_empty =	priv->init_vo_config ||
 				priv->playlist->len == 0;
@@ -511,6 +517,7 @@ observe_properties(CelluloidMpv *mpv)
 	celluloid_mpv_observe_property(mpv, 0, "volume-max", MPV_FORMAT_DOUBLE);
 	celluloid_mpv_observe_property(mpv, 0, "window-maximized", MPV_FORMAT_FLAG);
 	celluloid_mpv_observe_property(mpv, 0, "window-scale", MPV_FORMAT_DOUBLE);
+	celluloid_mpv_observe_property(mpv, 0, "time-pos", MPV_FORMAT_DOUBLE);
 }
 
 static gchar *
@@ -680,10 +687,10 @@ load_file(CelluloidMpv *mpv, const gchar *uri, gboolean append)
 	gboolean idle_active = FALSE;
 
 	g_object_get(mpv, "ready", &ready, NULL);
-
+/*
 	celluloid_mpv_get_property
 		(mpv, "idle-active", MPV_FORMAT_FLAG, &idle_active);
-
+*/
 	if(idle_active || !ready)
 	{
 		if(!append)
@@ -723,14 +730,14 @@ reset(CelluloidMpv *mpv)
 	gboolean idle_active = FALSE;
 	gint64 playlist_pos = 0;
 	gdouble volume = 0;
-
+/*
 	celluloid_mpv_get_property
 		(mpv, "idle-active", MPV_FORMAT_FLAG, &idle_active);
 	celluloid_mpv_get_property
 		(mpv, "playlist-pos", MPV_FORMAT_INT64, &playlist_pos);
 	celluloid_mpv_get_property
 		(mpv, "volume", MPV_FORMAT_DOUBLE, &volume);
-
+*/
 	CELLULOID_MPV_CLASS(celluloid_player_parent_class)->reset(mpv);
 
 	load_script_opts(CELLULOID_PLAYER(mpv));
@@ -1152,9 +1159,10 @@ update_playlist(CelluloidPlayer *player)
 	prefetch_metadata = g_settings_get_boolean(settings, "prefetch-metadata");
 
 	g_ptr_array_set_size(priv->playlist, 0);
-
+/*
 	celluloid_mpv_get_property
 		(CELLULOID_MPV(player), "playlist", MPV_FORMAT_NODE, &playlist);
+*/
 
 	org_list = playlist.u.list;
 
@@ -1202,9 +1210,10 @@ update_metadata(CelluloidPlayer *player)
 	mpv_node metadata;
 
 	g_ptr_array_set_size(priv->metadata, 0);
-
+/*
 	celluloid_mpv_get_property
 		(CELLULOID_MPV(player), "metadata", MPV_FORMAT_NODE, &metadata);
+*/
 
 	org_list = metadata.u.list;
 
@@ -1249,10 +1258,12 @@ update_chapter_list(CelluloidPlayer *player)
 	mpv_node chapter_list;
 
 	g_ptr_array_set_size(priv->chapter_list, 0);
+	/*
 	celluloid_mpv_get_property(	CELLULOID_MPV(player),
 					"chapter-list",
 					MPV_FORMAT_NODE,
 					&chapter_list );
+	*/
 
 	org_list = chapter_list.u.list;
 
@@ -1281,10 +1292,12 @@ update_track_list(CelluloidPlayer *player)
 	mpv_node track_list;
 
 	g_ptr_array_set_size(priv->track_list, 0);
+	/*
 	celluloid_mpv_get_property(	CELLULOID_MPV(player),
 					"track-list",
 					MPV_FORMAT_NODE,
 					&track_list );
+	*/
 
 	org_list = track_list.u.list;
 
@@ -1595,8 +1608,11 @@ void
 celluloid_player_remove_playlist_entry(CelluloidPlayer *player, gint64 position)
 {
 	CelluloidMpv *mpv = CELLULOID_MPV(player);
+	gboolean idle_active = FALSE;
+	/*
 	gboolean idle_active =	celluloid_mpv_get_property_flag
 				(mpv, "idle-active");
+	*/
 
 	if(idle_active)
 	{
@@ -1624,8 +1640,11 @@ celluloid_player_move_playlist_entry(	CelluloidPlayer *player,
 					gint64 dst )
 {
 	CelluloidMpv *mpv = CELLULOID_MPV(player);
+	gboolean idle_active = FALSE;
+	/*
 	gboolean idle_active =	celluloid_mpv_get_property_flag
 				(mpv, "idle-active");
+	*/
 
 	if(idle_active)
 	{


### PR DESCRIPTION
Setting `MPV_RENDER_PARAM_ADVANCED_CONTROL` slightly reduces memory and processor usage.

This needs some refactoring to avoid dead locks and keeping features.

`mpv_get_property` calls:
* Model
  * [x] `time-pos`
  * [ ] `input-bindings`
  * [ ] `shuffle`
  * [ ] `loop-playlist`
  * [ ] `dwidth` `dheight`
* MPV
  * [ ] `playlist-count`
  * [ ] `pause`
  * [ ] `loop-file`
  * [ ] `loop-playlist`
* Player options
  * [ ] `dwidth` `dheight`
  * [ ] `options/window-scale`
  * [ ] `options/autofit`
  * [ ] `options/autofit-larger`
  * [ ] `options/autofit-smaller`
  * [ ] `options/geometry`
  * [ ] `options/msg-level`
* Player
  * [ ] `vo-configured`
  * [ ] `idle-active`
  * [ ] `volume`
  * [ ] `playlist`
  * [ ] `metadata`
  * [ ] `chapter-list`
  * [ ] `track-list`
* Metadata cache
  * [ ] `path`
  * [ ] `duration`
  * [ ] `media-title`
  * [ ] `metadata`