### PR TITLE
video-area: Fix graphics offload toggle

### DIFF
--- a/src/celluloid-video-area.c
+++ b/src/celluloid-video-area.c
@@ -468,7 +468,7 @@ celluloid_video_area_init(CelluloidVideoArea *area)
 		g_settings_get_boolean(settings, "graphics-offload-enable");
 	gtk_graphics_offload_set_enabled
 		(	GTK_GRAPHICS_OFFLOAD(area->graphics_offload),
-			enable_graphics_offload );
+			!enable_graphics_offload );
 
 	AdwBreakpointCondition *wide_condition =
 		adw_breakpoint_condition_new_length


### PR DESCRIPTION
While testing the fix in b9004ea88629e61fec19e40c74ebd137d75ebcf8 I noticed that my system still showed the same issue. I then tried setting the "Enable graphics offload" switch to TRUE, and saw that it counterintuitively fixed it.

Looking at the code I realized that the second argument to `gtk_graphics_offload_set_enabled` is a `GraphicsOffloadEnabled` enum, where `0` means ENABLED, while `1` means DISABLED, which is the opposite of the gboolean extracted from the setting (see https://docs.gtk.org/gtk4/enum.GraphicsOffloadEnabled.html).

This adds a negation to the argument so it toggles the expected behaviour.

I guess a potentially cleaner solution instead of this quick fix might be to first convert the gboolean to a GraphicsOffloadEnabled enum and then passing that, instead of using it directly.