### PR TITLE
Force playback seekbar to be LTR

### DIFF
--- a/src/celluloid-control-box.c
+++ b/src/celluloid-control-box.c
@@ -737,6 +737,16 @@ celluloid_control_box_init(CelluloidControlBox *box)
 			"sidebar-show-right-symbolic",
 			_("Show Playlist") );
 
+	// RTL adjustments
+	if (gtk_button_get_child(GTK_BUTTON(box->forward_button)))
+          gtk_widget_set_direction(gtk_button_get_child(GTK_BUTTON(box->forward_button)), GTK_TEXT_DIR_LTR);
+	if (gtk_button_get_child(GTK_BUTTON(box->rewind_button)))
+          gtk_widget_set_direction(gtk_button_get_child(GTK_BUTTON(box->rewind_button)), GTK_TEXT_DIR_LTR);
+  	if (gtk_button_get_child(GTK_BUTTON(box->next_button)))
+          gtk_widget_set_direction(gtk_button_get_child(GTK_BUTTON(box->next_button)), GTK_TEXT_DIR_LTR);
+  	if (gtk_button_get_child(GTK_BUTTON(box->previous_button)))
+          gtk_widget_set_direction(gtk_button_get_child(GTK_BUTTON(box->previous_button)), GTK_TEXT_DIR_LTR);
+
 	gtk_widget_add_css_class(box->controls_box,"control-box");
 	gtk_widget_add_css_class(box->controls_box, "toolbar");
 	gtk_widget_add_css_class(box->title_widget, "heading");

--- a/src/celluloid-seek-bar.c
+++ b/src/celluloid-seek-bar.c
@@ -495,6 +495,7 @@ static void
 celluloid_seek_bar_init(CelluloidSeekBar *bar)
 {
 	bar->seek_bar = gtk_scale_new(GTK_ORIENTATION_HORIZONTAL, NULL);
+	gtk_widget_set_direction(bar->seek_bar, GTK_TEXT_DIR_LTR);
 	bar->label = celluloid_time_label_new();
 	bar->popover = g_object_ref_sink(gtk_popover_new());
 	bar->popover_label = gtk_label_new(NULL);


### PR DESCRIPTION
Although elements that depict the passage of time should be mirrored in RTL layouts, this does not apply to seekbars and media playback buttons, as they represent the direction of the tape rather than the flow of time.

References:
[Material Design conventions on bidrectionality](https://m2.material.io/design/usability/bidirectionality.html#mirroring-elements)
[GNOME Design Team mockups](https://gitlab.gnome.org/Teams/Design/app-mockups/-/issues/22)

Resolves #769 & resolves #966