### PR TITLE
macOS: Add support in get_proc_address

### DIFF
--- a/src/celluloid-mpv.c
+++ b/src/celluloid-mpv.c
@@ -41,6 +41,10 @@
 #include <gdk/win32/gdkwin32.h>
 #include <epoxy/wgl.h>
 #endif
+#ifdef GDK_WINDOWING_MACOS
+#include <gdk/macos/gdkmacos.h>
+#include <dlfcn.h>
+#endif
 
 #include "celluloid-mpv.h"
 #include "celluloid-common.h"
@@ -151,6 +155,10 @@ get_proc_address(void *fn_ctx, const gchar *name)
 #ifdef GDK_WINDOWING_WIN32
 	if (GDK_IS_WIN32_DISPLAY(display))
 		return wglGetProcAddress(name);
+#endif
+#ifdef GDK_WINDOWING_MACOS
+	if (GDK_IS_MACOS_DISPLAY(display))
+		return dlsym(RTLD_DEFAULT, name);
 #endif
 	g_assert_not_reached();
 	return NULL;


### PR DESCRIPTION
This allows celluloid to function within macOS, currently tested within macOS 26 Tahoe on an m4 mac mini, there's probably a better way to do this, but this method allows celluloid to work on macOS