### PR TITLE
Add `vcs-browser` to appdata

### DIFF
--- a/data/io.github.celluloid_player.Celluloid.appdata.xml.in
+++ b/data/io.github.celluloid_player.Celluloid.appdata.xml.in
@@ -619,5 +619,6 @@
  <url type="bugtracker">https://github.com/celluloid-player/celluloid/issues</url>
  <url type="donation">https://paypal.me/CelluloidProject</url>
  <url type="translate">https://hosted.weblate.org/projects/celluloid/</url>
+ <url type="vcs-browser">https://github.com/celluloid/celluloid</url>
  <update_contact>gnome-mpv@km.away.im</update_contact>
 </component>


### PR DESCRIPTION
Raised because Flathub linter gives a soft warning that there is no `vcs-browser` entry (link to source code) in the appdata file.